### PR TITLE
Simple command to list feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ See [keep a changelog] for information about writing changes to this log.
 - Tags normalization
 - Added rabbit MQ to the mix
 - Added monolog package
+- Added command to list feeds in the database
 
 [keep a changelog]: https://keepachangelog.com/en/1.1.0/
 [unreleased]: https://github.com/itk-dev/event-database-imports/compare/main...develop

--- a/src/Command/FeedListCommand.php
+++ b/src/Command/FeedListCommand.php
@@ -41,7 +41,14 @@ final class FeedListCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $status = $input->getOption('status');
         if (!in_array($status, self::SELECTIONS)) {
-            $io->error(sprintf('Status given not valid. Allowed values are (%s)', implode(', ', self::SELECTIONS)));
+            $io->error(sprintf('Invalid status: %s', $status));
+
+            // Show how to run this command.
+            // https://symfony.com/doc/current/console/calling_commands.html
+            $this->getApplication()->doRun(new ArrayInput([
+                'command' => $this->getName(),
+                '--help'  => true,
+            ]), $output);
 
             return Command::INVALID;
         }

--- a/src/Command/FeedListCommand.php
+++ b/src/Command/FeedListCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Command;
+
+use App\Repository\FeedRepository;
+use App\Services\Feeds\Mapper\FeedConfigurationMapper;
+use CuyZ\Valinor\Mapper\MappingError;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:feed:list',
+    description: 'List feeds from the database',
+)]
+final class FeedListCommand extends Command
+{
+    public function __construct(
+        private readonly FeedConfigurationMapper $configurationMapper,
+        private readonly FeedRepository $feedRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        // @todo: Add option to limit based on organization (data available in other PR currently).
+        $this->addOption('show-disabled', '', InputOption::VALUE_NONE, 'Also list disabled feeds');
+    }
+
+    /**
+     * @throws MappingError
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $showDisabled = $input->getOption('show-disabled');
+
+        if ($showDisabled) {
+            $feeds = $this->feedRepository->findAll();
+        } else {
+            $feeds = $this->feedRepository->findBy(['enabled' => !$showDisabled]);
+        }
+
+        foreach ($feeds as $feed) {
+            $config = $this->configurationMapper->getConfigurationFromArray($feed->getConfiguration());
+            $io->definitionList(
+                ['Id' => $feed->getId()],
+                ['Name' => $feed->getName()],
+                ['Url' => $config->url]
+            );
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/FeedListCommand.php
+++ b/src/Command/FeedListCommand.php
@@ -48,7 +48,8 @@ final class FeedListCommand extends Command
             $io->definitionList(
                 ['Id' => $feed->getId()],
                 ['Name' => $feed->getName()],
-                ['Url' => $config->url]
+                ['Url' => $config->url],
+                ['Enabled' => $feed->isEnabled()]
             );
         }
 

--- a/src/Command/FeedListCommand.php
+++ b/src/Command/FeedListCommand.php
@@ -39,11 +39,9 @@ final class FeedListCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $showDisabled = $input->getOption('show-disabled');
 
-        if ($showDisabled) {
-            $feeds = $this->feedRepository->findAll();
-        } else {
-            $feeds = $this->feedRepository->findBy(['enabled' => !$showDisabled]);
-        }
+        $feeds = $showDisabled
+          ? $this->feedRepository->findAll()
+          : $this->feedRepository->findBy(['enabled' => true]);
 
         foreach ($feeds as $feed) {
             $config = $this->configurationMapper->getConfigurationFromArray($feed->getConfiguration());

--- a/src/Command/FeedListCommand.php
+++ b/src/Command/FeedListCommand.php
@@ -7,6 +7,7 @@ use App\Services\Feeds\Mapper\FeedConfigurationMapper;
 use CuyZ\Valinor\Mapper\MappingError;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -35,6 +36,7 @@ final class FeedListCommand extends Command
 
     /**
      * @throws MappingError
+     * @throws \Throwable
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
@@ -45,9 +47,9 @@ final class FeedListCommand extends Command
 
             // Show how to run this command.
             // https://symfony.com/doc/current/console/calling_commands.html
-            $this->getApplication()->doRun(new ArrayInput([
+            $this->getApplication()?->doRun(new ArrayInput([
                 'command' => $this->getName(),
-                '--help'  => true,
+                '--help' => true,
             ]), $output);
 
             return Command::INVALID;


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/EV-288

#### Description

Simple command to list feeds currently in the database (with option to list disabled feeds as well).

#### Screenshot of the result

![Screenshot from 2023-09-06 16-04-52](https://github.com/itk-dev/event-database-imports/assets/111397/4401e28a-dddc-4837-8763-073e1bc83870)

#### Checklist

- [ ] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

Got tired of having to lookup ID's in the database after fixture changes and load.