### PR TITLE
1284: Added PethPrefix scope to traefik rules to allow co-hosting with legacy eventdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ See [keep a changelog] for information about writing changes to this log.
 - Updated feed mapping to support data migration
 - Added migrate command fro tags from legacy db
 - Updated elastic indexes to support the API
+- Added PethPrefix scope to traefik rules to allow co-hosting with legacy eventdb
 
 [keep a changelog]: https://keepachangelog.com/en/1.1.0/
 [unreleased]: https://github.com/itk-dev/event-database-imports/compare/main...develop

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -15,13 +15,13 @@ security:
             security: false
         main:
             form_login:
-                login_path: app_login
-                check_path: app_login
+                login_path: app_admin_login
+                check_path: app_admin_login
                 enable_csrf: true
 
             logout:
-                path: app_logout
-                target: app_login
+                path: app_admin_logout
+                target: app_admin_login
 
             # https://symfony.com/doc/current/security/impersonating_user.html
             # switch_user: true
@@ -29,6 +29,7 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
+        - { path: ^/admin/login, , roles: PUBLIC_ACCESS }
         - { path: ^/admin, roles: !php/enum App\Types\UserRoles::ROLE_API_USER->value }
         # - { path: ^/profile, roles: ROLE_USER }
 

--- a/docker-compose.server.override.yml
+++ b/docker-compose.server.override.yml
@@ -15,6 +15,14 @@ services:
     volumes:
       - "./.docker/data/rabbit:/var/lib/rabbitmq/mnesia"
 
+  nginx:
+    labels:
+      # Scope hosting by path prefix to allow shared hosting with legacy EventDB
+      # 'https://api.detskeriaarhus.dk/easyadmin/' -> Legacy EventDB
+      # 'https://api.detskeriaarhus.dk/admin/' -> EventDB v2
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-http.rule=Host(`${COMPOSE_SERVER_DOMAIN}`) && PathPrefix(`/admin`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_SERVER_DOMAIN}`) && PathPrefix(`/admin`)"
+
   supervisor:
     # @TODO: Create supervisor with ansible, when merged with Ture's PR
     image: itkdev/supervisor-php8.3:alpine

--- a/src/Controller/Admin/LoginController.php
+++ b/src/Controller/Admin/LoginController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Controller;
+namespace App\Controller\Admin;
 
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
 use Symfony\Component\HttpFoundation\Response;
@@ -15,7 +15,7 @@ class LoginController extends AbstractDashboardController
     ) {
     }
 
-    #[Route('/login', name: 'app_login')]
+    #[Route('/admin/login', name: 'app_admin_login')]
     public function index(): Response
     {
         $error = $this->authenticationUtils->getLastAuthenticationError();
@@ -41,7 +41,7 @@ class LoginController extends AbstractDashboardController
         ]);
     }
 
-    #[Route('/logout', name: 'app_logout', methods: ['GET'])]
+    #[Route('/admin/logout', name: 'app_admin_logout', methods: ['GET'])]
     public function logout(): never
     {
         throw new \Exception('Don\'t forget to activate logout in security.yaml');


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/tickets/showKanban?tab=timesheet#/tickets/showTicket/1284

#### Description

Added PethPrefix scope to traefik rules to allow co-hosting with legacy eventdb

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
