### PR TITLE
2547: Consolidate scheduled feed import and index populate in one command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ See [keep a changelog] for information about writing changes to this log.
 - Add `--force` option to `app:feed:import` command
 - Refactor feed import to enable feed cleanup
 - Handle local images
+- Consolidate scheduled feed import and index populate in one command
 
 [keep a changelog]: https://keepachangelog.com/en/1.1.0/
 [unreleased]: https://github.com/itk-dev/event-database-imports/compare/main...develop

--- a/src/Command/Index/IndexPopulateCommand.php
+++ b/src/Command/Index/IndexPopulateCommand.php
@@ -13,13 +13,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Scheduler\Attribute\AsCronTask;
 
 #[AsCommand(
     name: 'app:index:populate',
     description: 'Populate (re-index) an index',
 )]
-#[AsCronTask(expression: '30 * * * *', schedule: 'default')]
 final class IndexPopulateCommand extends Command
 {
     public function __construct(

--- a/src/Command/Schedule/ImportAndPopulateCommand.php
+++ b/src/Command/Schedule/ImportAndPopulateCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Command\Schedule;
+
+use App\Model\Indexing\IndexNames;
+use App\Service\Feeds\Reader\FeedReader;
+use App\Service\Populate;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Scheduler\Attribute\AsCronTask;
+
+#[AsCommand(
+    name: 'app:schedule:import-and-populate',
+    description: 'Import feeds and populate index',
+)]
+#[AsCronTask(expression: '20 * * * *', schedule: 'default')]
+class ImportAndPopulateCommand extends Command
+{
+    public function __construct(
+        private readonly FeedReader $feedReader,
+        private readonly Populate $populate,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            $this->feedReader->readFeeds();
+
+            foreach (IndexNames::values() as $indexName) {
+                $this->populate->populate($indexName);
+            }
+
+            return Command::SUCCESS;
+        } catch (\Throwable $e) {
+            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+
+            return Command::FAILURE;
+        }
+    }
+}

--- a/src/Service/Feeds/Reader/FeedReader.php
+++ b/src/Service/Feeds/Reader/FeedReader.php
@@ -14,7 +14,6 @@ use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\TransportNamesStamp;
 
-
 class FeedReader implements FeedReaderInterface
 {
     public const string SYNC_QUEUE = 'sync';

--- a/src/Service/Feeds/Reader/FeedReader.php
+++ b/src/Service/Feeds/Reader/FeedReader.php
@@ -13,9 +13,8 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\TransportNamesStamp;
-use Symfony\Component\Scheduler\Attribute\AsCronTask;
 
-#[AsCronTask(expression: '20 * * * *', schedule: 'default', method: 'readFeeds')]
+
 class FeedReader implements FeedReaderInterface
 {
     public const string SYNC_QUEUE = 'sync';


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/tickets/showKanban?tab=ticketdetails#/tickets/showTicket/2547

#### Description

Consolidate scheduled feed import and index populate in one command

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
