### PR TITLE
3944: Include path in check for local image resource to avoid falsely…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+## [1.1.4] - 2025-03-05
+
+- Include path in check for local image resource to avoid falsely identifying images from "v1" as local
+
 ## [1.1.3] - 2025-03-03
 
 - Change DailyOccurrences to split midnight local time

--- a/src/Service/ImageService.php
+++ b/src/Service/ImageService.php
@@ -24,6 +24,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final readonly class ImageService implements ImageServiceInterface
 {
+    private const LOCAL_IMAGE_PREFIX = '/images';
+
     public function __construct(
         private HttpClientInterface $client,
         private string $publicPath,
@@ -51,12 +53,12 @@ final readonly class ImageService implements ImageServiceInterface
 
     private function isLocalResource(string $url): bool
     {
-        return str_starts_with($url, $this->defaultUri);
+        return str_starts_with($url, $this->defaultUri.self::LOCAL_IMAGE_PREFIX);
     }
 
     private function getLocalResourcePath(string $url): string
     {
-        $file = str_replace($this->defaultUri.'/images', '', $url);
+        $file = str_replace($this->defaultUri.self::LOCAL_IMAGE_PREFIX, '', $url);
 
         return $this->getRelativePath($file);
     }


### PR DESCRIPTION
… identifying images from "v1" as local

#### Link to ticket

https://leantime.itkdev.dk/auth/login#/tickets/showTicket/3944

#### Description

- Include path in check for local image resource to avoid falsely identifying images from "v1" as local

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
