### PR TITLE
4101: Set "updated at" to newest of either entity or entity relations when indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ node_modules/
 ###> phpunit/phpunit ###
 /phpunit.xml
 .phpunit.result.cache
+coverage
 ###< phpunit/phpunit ###
 
 ###> liip/imagine-bundle ###

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
-- Set "updated at" to newest of either entity or entity relations when indexing 
+- Set "updated at" to newest of either entity or entity relations when indexing
 
 ## [1.1.5] - 2025-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- Set "updated at" to newest of either entity or entity relations when indexing 
+
 ## [1.1.5] - 2025-03-12
 
 - Add labels to Woodpecker workflow

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -247,12 +247,6 @@ parameters:
 			path: src/Repository/VocabularyRepository.php
 
 		-
-			message: '#^Call to an undefined method App\\Service\\Indexing\\IndexItemInterface\:\:getEvent\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Service/Indexing/IndexingDailyOccurrences.php
-
-		-
 			message: '#^Call to an undefined method Symfony\\Component\\Serializer\\SerializerInterface\:\:normalize\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -287,12 +281,6 @@ parameters:
 			identifier: method.notFound
 			count: 1
 			path: src/Service/Indexing/IndexingLocations.php
-
-		-
-			message: '#^Call to an undefined method App\\Service\\Indexing\\IndexItemInterface\:\:getEvent\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Service/Indexing/IndexingOccurrences.php
 
 		-
 			message: '#^Call to an undefined method Symfony\\Component\\Serializer\\SerializerInterface\:\:normalize\(\)\.$#'

--- a/src/Service/Indexing/IndexingDailyOccurrences.php
+++ b/src/Service/Indexing/IndexingDailyOccurrences.php
@@ -2,6 +2,7 @@
 
 namespace App\Service\Indexing;
 
+use App\Entity\DailyOccurrence;
 use App\Model\Indexing\IndexFieldTypes;
 use App\Model\Indexing\IndexNames;
 use Elastic\Elasticsearch\Client;
@@ -25,6 +26,13 @@ final class IndexingDailyOccurrences extends AbstractIndexingElastic
 
     public function serialize(IndexItemInterface $item): array
     {
+        if (!$item instanceof DailyOccurrence) {
+            throw new \InvalidArgumentException('Item must be an instance of DailyOccurrence.');
+        }
+
+        $updatedAt = $this->getUpdatedAt($item);
+        $item->setUpdatedAt($updatedAt);
+
         $contextBuilder = (new ObjectNormalizerContextBuilder())
             ->withGroups([IndexNames::Occurrences->value]);
         $contextBuilder = (new DateTimeNormalizerContextBuilder())
@@ -38,5 +46,25 @@ final class IndexingDailyOccurrences extends AbstractIndexingElastic
         $data['event'] = $this->indexingEvents->serialize($item->getEvent());
 
         return $data;
+    }
+
+    private function getUpdatedAt(DailyOccurrence $occurrence): \DateTime
+    {
+        $updatedAt = $occurrence->getUpdatedAt();
+        $event = $occurrence->getEvent();
+
+        $updatedAt = max($updatedAt, $event->getOrganization()?->getUpdatedAt());
+        $updatedAt = max($updatedAt, $event->getLocation()?->getUpdatedAt());
+        $updatedAt = max($updatedAt, $event->getImage()?->getUpdatedAt());
+
+        foreach ($event->getPartners() as $partner) {
+            $updatedAt = max($updatedAt, $partner->getUpdatedAt());
+        }
+
+        foreach ($event->getOccurrences() as $occurrence) {
+            $updatedAt = max($updatedAt, $occurrence->getUpdatedAt());
+        }
+
+        return $updatedAt;
     }
 }


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/?tab=timesheet#/tickets/showTicket/4101

#### Description

Set "updated at" to newest of either entity or entity relations when indexing.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
