### PR TITLE
4122: Fix start/end not required for occurrences in EasyAdmin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- Fix start/end not required for occurrences in EasyAdmin
+
 ## [1.1.5] - 2025-03-12
 
 - Add labels to Woodpecker workflow

--- a/src/Controller/Admin/EmbedOccurrenceCrudController.php
+++ b/src/Controller/Admin/EmbedOccurrenceCrudController.php
@@ -29,9 +29,11 @@ class EmbedOccurrenceCrudController extends AbstractBaseCrudController
             FormField::addFieldset('Dates')
                 ->setLabel(new TranslatableMessage('admin.occurrence.dates.headline')),
             DateTimeField::new('start')
+                ->setHtmlAttribute('required', 'required')
                 ->setLabel(new TranslatableMessage('admin.occurrence.dates.start'))
                 ->setColumns(6),
             DateTimeField::new('end')
+                ->setHtmlAttribute('required', 'required')
                 ->setLabel(new TranslatableMessage('admin.occurrence.dates.end'))
                 ->setColumns(6),
 

--- a/src/Entity/Occurrence.php
+++ b/src/Entity/Occurrence.php
@@ -13,6 +13,7 @@ use Gedmo\SoftDeleteable\Traits\SoftDeleteableEntity;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\SerializedPath;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: OccurrenceRepository::class)]
 class Occurrence implements IndexItemInterface, EditableEntityInterface
@@ -28,12 +29,17 @@ class Occurrence implements IndexItemInterface, EditableEntityInterface
     #[SerializedPath('[entityId]')]
     private ?int $id = null;
 
-    #[ORM\Column]
+    #[ORM\Column(nullable: false)]
     #[Groups([IndexNames::Events->value, IndexNames::Occurrences->value])]
     private ?\DateTimeImmutable $start = null;
 
-    #[ORM\Column]
+    #[ORM\Column(nullable: false)]
     #[Groups([IndexNames::Events->value, IndexNames::Occurrences->value])]
+    #[Assert\DateTime]
+    #[Assert\Expression(
+        'this.getStart() < this.getEnd()',
+        message: 'The start date must be before the end date'
+    )]
     private ?\DateTimeImmutable $end = null;
 
     #[ORM\Column(length: 255, nullable: true)]


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/?tab=timesheet#/tickets/showTicket/4122

#### Description

- Fix start/end not required for occurrences in EasyAdmin

#### Screenshot of the result

![Screenshot 2025-03-26 at 21 42 53](https://github.com/user-attachments/assets/5614581c-d687-4c99-a09d-4ddf87ecfe9c)


#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
