### PR TITLE
fix: apply feed guard before SAVE actions in EventVoter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
-- [PR-XX](https://github.com/itk-dev/event-database-imports/pull/XX)
+- [PR-85](https://github.com/itk-dev/event-database-imports/pull/85)
   Fix EventVoter so feed events cannot be edited via SAVE actions (feed guard runs before the save grant)
 - [PR-84](https://github.com/itk-dev/event-database-imports/pull/84)
   Upgrade to PHPUnit 13 and tooling majors (twig-cs-fixer 4, reflection-docblock 6, phpdoc-parser 2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-XX](https://github.com/itk-dev/event-database-imports/pull/XX)
+  Fix EventVoter so feed events cannot be edited via SAVE actions (feed guard runs before the save grant)
 - [PR-84](https://github.com/itk-dev/event-database-imports/pull/84)
   Upgrade to PHPUnit 13 and tooling majors (twig-cs-fixer 4, reflection-docblock 6, phpdoc-parser 2)
 - [PR-83](https://github.com/itk-dev/event-database-imports/pull/83)

--- a/src/Security/Voter/EventVoter.php
+++ b/src/Security/Voter/EventVoter.php
@@ -40,16 +40,17 @@ final class EventVoter extends Voter
             return true;
         }
 
+        // Feed events can never be edited or deleted. Apply this before any
+        // save-action grant below so it cannot be bypassed via SAVE_AND_*.
+        if (null !== $event->getFeed()) {
+            return false;
+        }
+
         if (Action::SAVE_AND_ADD_ANOTHER === $action || Action::SAVE_AND_CONTINUE === $action || Action::SAVE_AND_RETURN === $action) {
             // Allow event creation
             if ($this->security->isGranted(UserRoles::ROLE_ORGANIZATION_EDITOR->value)) {
                 return true;
             }
-        }
-
-        // Feed events can never be edited or deleted
-        if (null !== $event->getFeed()) {
-            return false;
         }
 
         // Global Admin/Editor users can edit all events except feed events

--- a/tests/Unit/Security/Voter/EventVoterTest.php
+++ b/tests/Unit/Security/Voter/EventVoterTest.php
@@ -114,16 +114,11 @@ final class EventVoterTest extends TestCase
     }
 
     /**
-     * Documents a known production gap: EventVoter grants SAVE_AND_* to org
-     * editors before the feed-event guard runs, so the "feed events cannot be
-     * edited" rule is bypassed for save actions. Remove the skip once the
-     * voter is reordered (tracked separately from this test-coverage PR).
+     * Feed events must never be editable, including via SAVE_AND_* actions:
+     * the feed guard runs before the save-action grant.
      */
     public function testFeedEventsCannotBeSavedByOrganizationEditor(): void
     {
-        $this->markTestSkipped('EventVoter grants SAVE_AND_* before the feed guard (src/Security/Voter/EventVoter.php:43). Follow-up issue.');
-
-        // @phpstan-ignore-next-line unreachable code retained as executable documentation of the desired behaviour.
         $voter = new EventVoter($this->createSecurity([UserRoles::ROLE_ORGANIZATION_EDITOR->value]));
         $token = $this->createToken(new User());
 


### PR DESCRIPTION
Feed-imported events must never be editable (ADR 007). `EventVoter` granted `SAVE_AND_*` actions to org editors **before** the "feed events can never be edited" guard, so an organisation editor could POST a save against a feed event and have it accepted — bypassing the rule the `EDIT` path enforces.

Surfaced by the PR #76 review (was tracked as a deferred issue with a skipped regression test).

## Fix (TDD red → green)

- **Red**: un-skipped `EventVoterTest::testFeedEventsCannotBeSavedByOrganizationEditor` — it failed (feed-event `SAVE_AND_*` returned `ACCESS_GRANTED`).
- **Green**: moved the feed guard (`null !== $event->getFeed()` → deny) ahead of the `SAVE_AND_*` grant in `voteOnAttribute()`, so no save-action grant can override it. `DETAIL`/`INDEX` remain allowed for feed events (they return before the guard).

## Verification

- The previously-skipped test now passes; full suite 128 passing, **skips 2 → 1**.
- `vendor/bin/phpstan analyse` — clean.

## Scope note

This is the first of a few scoped PRs fixing authorization gaps deferred from #76. This one is the feed-guard ordering only. The broader NEW-action URL enforcement (all CRUD voters) and the `UserActionVoter` type-assertion fix follow in separate PRs. A related cross-org SAVE observation (an org editor saving a *non-feed* event outside their org via SAVE_AND_*) is noted for follow-up — it needs create-vs-edit distinction and is out of scope here.