### PR TITLE
fix: enforce NEW-action authorization on CRUD voters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-XX](https://github.com/itk-dev/event-database-imports/pull/XX)
+  Enforce NEW-action authorization at the URL level on the CRUD voters, scope EventVoter save actions to the user's
+  organization, and document the roles/permissions matrix in the README
 - [PR-85](https://github.com/itk-dev/event-database-imports/pull/85)
   Fix EventVoter so feed events cannot be edited via SAVE actions (feed guard runs before the save grant)
 - [PR-84](https://github.com/itk-dev/event-database-imports/pull/84)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
-- [PR-XX](https://github.com/itk-dev/event-database-imports/pull/XX)
+- [PR-86](https://github.com/itk-dev/event-database-imports/pull/86)
   Enforce NEW-action authorization at the URL level on the CRUD voters, scope EventVoter save actions to the user's
   organization, and document the roles/permissions matrix in the README
 - [PR-85](https://github.com/itk-dev/event-database-imports/pull/85)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ task fixtures:load
 After loading fixtures, you can sign (on `/admin/login`) in as one of these users:
 
 | Username           | Password     | Roles        |
-|--------------------|--------------|--------------|
+| ------------------ | ------------ | ------------ |
 | `admin@itkdev.dk`  | `admin`      | `ROLE_ADMIN` |
 | `tester@itkdev.dk` | `1233456789` | `ROLE_ADMIN` |
 
@@ -116,12 +116,53 @@ Using all three repositories, you can create the setup depicted below and have c
 
 ![Network setup production](./docs/images/networks.png)
 
+## Roles and permissions
+
+Sign-in is local username/password (Symfony `form_login`). Admin-UI authorization is enforced by voters in
+`src/Security/Voter/` (keyed on EasyAdmin's per-action `EA_EXECUTE_ACTION` permission). Roles are defined in
+`src/Types/UserRoles.php` and form an inheritance chain in `config/packages/security.yaml` — each role also holds
+every capability of the roles to its right:
+
+```text
+SUPER_ADMIN → ADMIN → EDITOR → ORGANIZATION_ADMIN → ORGANIZATION_EDITOR → API_USER → USER
+```
+
+`ROLE_API_USER` is used by the read [`event-database-api`](https://github.com/itk-dev/event-database-api);
+`ROLE_USER` is any authenticated user. In the matrix, "+" means "that role and everything above it".
+
+| Entity       | View (index/detail) | Create                 | Edit                                                        | Delete                                    |
+| ------------ | ------------------- | ---------------------- | ----------------------------------------------------------- | ----------------------------------------- |
+| Organization | any user            | `EDITOR`+              | `EDITOR`+ · `ORGANIZATION_ADMIN` (own org)                  | `EDITOR`+                                 |
+| Event        | any user            | `ORGANIZATION_EDITOR`+ | `EDITOR`+ · `ORGANIZATION_EDITOR` (own-org) — non-feed only | `EDITOR`+ (non-feed)                      |
+| Location     | any user            | `EDITOR`+ ¹            | `EDITOR`+                                                   | `EDITOR`+ (only when it has no events)    |
+| Address      | any user            | `EDITOR`+ ¹            | `EDITOR`+                                                   | `EDITOR`+ (only when it has no locations) |
+| Tag          | any user            | any user ²             | `ADMIN`+                                                    | `ADMIN`+                                  |
+| Vocabulary   | `ADMIN`+            | `ADMIN`+               | `ADMIN`+                                                    | `ADMIN`+                                  |
+| Feed         | `ADMIN`+            | `SUPER_ADMIN`          | `SUPER_ADMIN`                                               | `SUPER_ADMIN`                             |
+| Feed item    | `ADMIN`+            | — (import-managed) ³   | — ³                                                         | — ³                                       |
+| User         | `ADMIN`+ or self    | `ADMIN`+               | `ADMIN`+ · others: self only                                | `ADMIN`+ (never your own account)         |
+
+- **Feed-imported events are never editable or deletable** by anyone (ADR 007) — they change only via re-import.
+- **Own-org scoping**: organization admins/editors may act only on entities belonging to their own organization(s).
+- ¹ Organization admins can additionally create locations/addresses **inline** while creating an event (the save-action
+  grant), even though the standalone `New` page is editor-gated.
+- ² Anyone may create a bare tag, but assigning a tag to a vocabulary (the tag's `vocabularies` field) is `ADMIN`-only.
+- **Vocabularies** (controlled tag vocabularies) are `ADMIN`-only for every action, enforced at the controller level
+  (`VocabularyCrudController::configureActions()` via `setPermission`) rather than by a voter.
+- **Feeds** are visible to `ADMIN`+ but only `SUPER_ADMIN` may create/edit/delete them; **Feed items** are read-only in
+  the admin (create/edit/delete disabled) — they change only via feed import (ADR 007). Both are enforced via
+  controller `setPermission`.
+- **Occurrences** are edited inline within an event (an embedded CRUD), not as a standalone entity. The "My …" menu
+  entries are organization-scoped views of Event/Organization for organization editors, not separate entities.
+- Users are also gated by `UserEntityVoter` (`EA_ACCESS_ENTITY`): anonymous denied; `ADMIN`+ any user; otherwise own
+  record only.
+
 ## Testing
 
 The test suite is built on [PHPUnit](https://phpunit.de/) and split into two suites (see `phpunit.xml.dist`):
 
-* **Unit** (`tests/Unit`) — isolated tests with no database, e.g. security voters and services.
-* **Functional** (`tests/Functional`) — boot the kernel and exercise the app against a real database (authentication,
+- **Unit** (`tests/Unit`) — isolated tests with no database, e.g. security voters and services.
+- **Functional** (`tests/Functional`) — boot the kernel and exercise the app against a real database (authentication,
   admin CRUD, filters).
 
 Run the whole suite with [Task](https://taskfile.dev):

--- a/src/Security/Voter/AddressVoter.php
+++ b/src/Security/Voter/AddressVoter.php
@@ -20,18 +20,21 @@ final class AddressVoter extends Voter
 
     protected function supports(string $attribute, mixed $subject): bool
     {
-        return Permission::EA_EXECUTE_ACTION == $attribute
-            && null !== $subject['entity']
-            && Address::class === $subject['entity']->getFqcn();
+        if (Permission::EA_EXECUTE_ACTION != $attribute) {
+            return false;
+        }
+
+        // EasyAdmin passes a null entity for INDEX/NEW but always sets entityFqcn,
+        // so match on that to keep NEW enforced at the URL level.
+        $fqcn = $subject['entityFqcn'] ?? $subject['entity']?->getFqcn();
+
+        return Address::class === $fqcn;
     }
 
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
     {
         $user = $token->getUser();
         assert($user instanceof User);
-
-        $address = $subject['entity']->getInstance();
-        assert($address instanceof Address);
 
         $action = is_string($subject['action']) ? $subject['action'] : $subject['action']->getName();
 
@@ -40,6 +43,15 @@ final class AddressVoter extends Voter
             return true;
         }
 
+        // New action is only allowed for editors (no entity instance yet)
+        if (Action::NEW === $action) {
+            return $this->security->isGranted(UserRoles::ROLE_EDITOR->value);
+        }
+
+        // Remaining actions operate on a concrete address instance
+        $address = $subject['entity']->getInstance();
+        assert($address instanceof Address);
+
         if (Action::SAVE_AND_ADD_ANOTHER === $action || Action::SAVE_AND_CONTINUE === $action || Action::SAVE_AND_RETURN === $action) {
             // Allow address creation
             if ($this->security->isGranted(UserRoles::ROLE_ORGANIZATION_ADMIN->value)) {
@@ -47,8 +59,8 @@ final class AddressVoter extends Voter
             }
         }
 
-        // Delete and New actions are only allowed for editors
-        if (Action::DELETE === $action || Action::NEW === $action) {
+        // Delete is only allowed for editors, and only for unused addresses
+        if (Action::DELETE === $action) {
             if ($this->security->isGranted(UserRoles::ROLE_EDITOR->value)) {
                 return 0 === $address->getLocations()->count();
             }

--- a/src/Security/Voter/EventVoter.php
+++ b/src/Security/Voter/EventVoter.php
@@ -20,18 +20,21 @@ final class EventVoter extends Voter
 
     protected function supports(string $attribute, mixed $subject): bool
     {
-        return Permission::EA_EXECUTE_ACTION == $attribute
-            && null !== $subject['entity']
-            && Event::class === $subject['entity']->getFqcn();
+        if (Permission::EA_EXECUTE_ACTION != $attribute) {
+            return false;
+        }
+
+        // EasyAdmin passes a null entity for INDEX/NEW but always sets entityFqcn,
+        // so match on that to keep NEW enforced at the URL level.
+        $fqcn = $subject['entityFqcn'] ?? $subject['entity']?->getFqcn();
+
+        return Event::class === $fqcn;
     }
 
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
     {
         $user = $token->getUser();
         assert($user instanceof User);
-
-        $event = $subject['entity']->getInstance();
-        assert($event instanceof Event);
 
         $action = is_string($subject['action']) ? $subject['action'] : $subject['action']->getName();
 
@@ -40,6 +43,15 @@ final class EventVoter extends Voter
             return true;
         }
 
+        // New action requires the organization editor role (no entity instance yet)
+        if (Action::NEW === $action) {
+            return $this->security->isGranted(UserRoles::ROLE_ORGANIZATION_EDITOR->value);
+        }
+
+        // Remaining actions operate on a concrete event instance
+        $event = $subject['entity']->getInstance();
+        assert($event instanceof Event);
+
         // Feed events can never be edited or deleted. Apply this before any
         // save-action grant below so it cannot be bypassed via SAVE_AND_*.
         if (null !== $event->getFeed()) {
@@ -47,9 +59,17 @@ final class EventVoter extends Voter
         }
 
         if (Action::SAVE_AND_ADD_ANOTHER === $action || Action::SAVE_AND_CONTINUE === $action || Action::SAVE_AND_RETURN === $action) {
-            // Allow event creation
-            if ($this->security->isGranted(UserRoles::ROLE_ORGANIZATION_EDITOR->value)) {
+            // Global editors may save any event.
+            if ($this->security->isGranted(UserRoles::ROLE_EDITOR->value)) {
                 return true;
+            }
+
+            // Organization editors may only save events for their own organization(s),
+            // mirroring the edit-path scoping below.
+            if ($this->security->isGranted(UserRoles::ROLE_ORGANIZATION_EDITOR->value)) {
+                $organization = $event->getOrganization();
+
+                return null !== $organization && $user->getOrganizations()->contains($organization);
             }
         }
 

--- a/src/Security/Voter/LocationVoter.php
+++ b/src/Security/Voter/LocationVoter.php
@@ -20,18 +20,21 @@ final class LocationVoter extends Voter
 
     protected function supports(string $attribute, mixed $subject): bool
     {
-        return Permission::EA_EXECUTE_ACTION == $attribute
-            && null !== $subject['entity']
-            && Location::class === $subject['entity']->getFqcn();
+        if (Permission::EA_EXECUTE_ACTION != $attribute) {
+            return false;
+        }
+
+        // EasyAdmin passes a null entity for INDEX/NEW but always sets entityFqcn,
+        // so match on that to keep NEW enforced at the URL level.
+        $fqcn = $subject['entityFqcn'] ?? $subject['entity']?->getFqcn();
+
+        return Location::class === $fqcn;
     }
 
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
     {
         $user = $token->getUser();
         assert($user instanceof User);
-
-        $location = $subject['entity']->getInstance();
-        assert($location instanceof Location);
 
         $action = is_string($subject['action']) ? $subject['action'] : $subject['action']->getName();
 
@@ -40,6 +43,15 @@ final class LocationVoter extends Voter
             return true;
         }
 
+        // New action is only allowed for editors (no entity instance yet)
+        if (Action::NEW === $action) {
+            return $this->security->isGranted(UserRoles::ROLE_EDITOR->value);
+        }
+
+        // Remaining actions operate on a concrete location instance
+        $location = $subject['entity']->getInstance();
+        assert($location instanceof Location);
+
         if (Action::SAVE_AND_ADD_ANOTHER === $action || Action::SAVE_AND_CONTINUE === $action || Action::SAVE_AND_RETURN === $action) {
             // Allow location creation
             if ($this->security->isGranted(UserRoles::ROLE_ORGANIZATION_ADMIN->value)) {
@@ -47,8 +59,8 @@ final class LocationVoter extends Voter
             }
         }
 
-        // Delete and New actions are only allowed for editors
-        if (Action::DELETE === $action || Action::NEW === $action) {
+        // Delete is only allowed for editors, and only for unused locations
+        if (Action::DELETE === $action) {
             if ($this->security->isGranted(UserRoles::ROLE_EDITOR->value)) {
                 return 0 === $location->getEvents()->count();
             }

--- a/src/Security/Voter/OrganizationVoter.php
+++ b/src/Security/Voter/OrganizationVoter.php
@@ -20,18 +20,21 @@ final class OrganizationVoter extends Voter
 
     protected function supports(string $attribute, mixed $subject): bool
     {
-        return Permission::EA_EXECUTE_ACTION == $attribute
-            && null !== $subject['entity']
-            && Organization::class === $subject['entity']->getFqcn();
+        if (Permission::EA_EXECUTE_ACTION != $attribute) {
+            return false;
+        }
+
+        // EasyAdmin passes a null entity for INDEX/NEW but always sets entityFqcn,
+        // so match on that to keep NEW enforced at the URL level.
+        $fqcn = $subject['entityFqcn'] ?? $subject['entity']?->getFqcn();
+
+        return Organization::class === $fqcn;
     }
 
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
     {
         $user = $token->getUser();
         assert($user instanceof User);
-
-        $organization = $subject['entity']->getInstance();
-        assert($organization instanceof Organization);
 
         $action = is_string($subject['action']) ? $subject['action'] : $subject['action']->getName();
 
@@ -40,13 +43,18 @@ final class OrganizationVoter extends Voter
             return true;
         }
 
-        // Delete and New actions are only allowed for editors
-        if (Action::DELETE === $action || Action::NEW === $action) {
-            if ($this->security->isGranted(UserRoles::ROLE_EDITOR->value)) {
-                return true;
-            }
+        // New action is only allowed for editors (EasyAdmin provides no instance yet)
+        if (Action::NEW === $action) {
+            return $this->security->isGranted(UserRoles::ROLE_EDITOR->value);
+        }
 
-            return false;
+        // Remaining actions operate on a concrete entity instance
+        $organization = $subject['entity']->getInstance();
+        assert($organization instanceof Organization);
+
+        // Delete is only allowed for editors
+        if (Action::DELETE === $action) {
+            return $this->security->isGranted(UserRoles::ROLE_EDITOR->value);
         }
 
         // Global Admin/Editor users can edit all organizations

--- a/src/Security/Voter/TagVoter.php
+++ b/src/Security/Voter/TagVoter.php
@@ -3,7 +3,6 @@
 namespace App\Security\Voter;
 
 use App\Entity\Tag;
-use App\Entity\User;
 use App\Types\UserRoles;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
@@ -20,28 +19,27 @@ final class TagVoter extends Voter
 
     protected function supports(string $attribute, mixed $subject): bool
     {
-        return Permission::EA_EXECUTE_ACTION == $attribute
-            && null !== $subject['entity']
-            && Tag::class === $subject['entity']->getFqcn();
+        if (Permission::EA_EXECUTE_ACTION != $attribute) {
+            return false;
+        }
+
+        // EasyAdmin passes a null entity for INDEX/NEW but always sets entityFqcn.
+        $fqcn = $subject['entityFqcn'] ?? $subject['entity']?->getFqcn();
+
+        return Tag::class === $fqcn;
     }
 
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
     {
-        $user = $token->getUser();
-        assert($user instanceof User);
-
-        $tag = $subject['entity']->getInstance();
-        assert($tag instanceof Tag);
-
         $action = is_string($subject['action']) ? $subject['action'] : $subject['action']->getName();
 
-        // Delete actions are only allowed for admins
+        // Delete and edit are only allowed for admins.
         if (Action::DELETE === $action || Action::EDIT === $action) {
-            if (!$this->security->isGranted(UserRoles::ROLE_ADMIN->value)) {
-                return false;
-            }
+            return $this->security->isGranted(UserRoles::ROLE_ADMIN->value);
         }
 
+        // Index, detail, new and save are open to any authenticated user
+        // (assigning a tag to a vocabulary is gated separately on the form field).
         return true;
     }
 }

--- a/tests/Functional/Admin/CrudSmokeTest.php
+++ b/tests/Functional/Admin/CrudSmokeTest.php
@@ -80,6 +80,12 @@ final class CrudSmokeTest extends AbstractAdminTestCase
         yield 'editor: tag index' => [TagCrudController::class, Action::INDEX, TestUserFixtures::EDITOR_EMAIL, self::EXPECT_SUCCESS];
         yield 'org editor: tag index' => [TagCrudController::class, Action::INDEX, TestUserFixtures::ORG_EDITOR_A_EMAIL, self::EXPECT_SUCCESS];
 
+        // NEW pages are enforced at the URL level, not just hidden: sub-editor roles are denied.
+        yield 'org admin denied: address new' => [AddressCrudController::class, Action::NEW, TestUserFixtures::ORG_ADMIN_A_EMAIL, self::EXPECT_DENIED];
+        yield 'org admin denied: location new' => [LocationCrudController::class, Action::NEW, TestUserFixtures::ORG_ADMIN_A_EMAIL, self::EXPECT_DENIED];
+        // Tags remain creatable by any authenticated user.
+        yield 'org editor: tag new' => [TagCrudController::class, Action::NEW, TestUserFixtures::ORG_EDITOR_A_EMAIL, self::EXPECT_SUCCESS];
+
         // Org editors get their own "My*" screens.
         yield 'org editor: my event index' => [MyEventCrudController::class, Action::INDEX, TestUserFixtures::ORG_EDITOR_A_EMAIL, self::EXPECT_SUCCESS];
         yield 'org editor: my event new' => [MyEventCrudController::class, Action::NEW, TestUserFixtures::ORG_EDITOR_A_EMAIL, self::EXPECT_SUCCESS];

--- a/tests/Functional/Admin/OrganizationCrudTest.php
+++ b/tests/Functional/Admin/OrganizationCrudTest.php
@@ -59,19 +59,15 @@ final class OrganizationCrudTest extends AbstractAdminTestCase
     }
 
     /**
-     * Would verify org admins cannot create organizations, but is currently skipped.
+     * An organization admin (non-editor) is denied URL-level access to the NEW form.
      */
     public function testOrgAdminCannotCreateOrganization(): void
     {
-        // The OrganizationCrudController hides the "New" button from the
-        // index page for non-editors via configureActions(), but EasyAdmin
-        // calls the EA_EXECUTE_ACTION voter with a null entity for the NEW
-        // action (see AbstractCrudController::new). The OrganizationVoter
-        // requires a non-null entity in supports() and therefore abstains,
-        // so the URL remains accessible. The enforcement is done in the UI,
-        // not at the URL level, and the configureActions() behaviour is
-        // covered elsewhere.
-        $this->markTestSkipped('URL-level access is not enforced for NEW; see OrganizationVoter::supports().');
+        $this->loginAs(TestUserFixtures::ORG_ADMIN_A_EMAIL);
+        $this->client->request('GET', $this->adminUrl(OrganizationCrudController::class, Action::NEW));
+
+        $status = $this->client->getResponse()->getStatusCode();
+        $this->assertContains($status, [302, 403], sprintf('Expected 302 or 403 for NEW, got %d', $status));
     }
 
     /**

--- a/tests/Unit/Security/Voter/EventVoterTest.php
+++ b/tests/Unit/Security/Voter/EventVoterTest.php
@@ -78,19 +78,49 @@ final class EventVoterTest extends TestCase
     }
 
     /**
-     * Grants save actions to a user with the organization editor role.
+     * Grants save actions to an organization editor for an event owned by their own organization.
      */
     public function testSaveActionsAllowedForOrganizationEditor(): void
     {
         $voter = new EventVoter($this->createSecurity([UserRoles::ROLE_ORGANIZATION_EDITOR->value]));
-        $token = $this->createToken(new User());
+
+        $org = new Organization();
+        $user = new User();
+        $user->addOrganization($org);
+
         $event = new Event();
+        $event->setOrganization($org);
 
         foreach ([Action::SAVE_AND_ADD_ANOTHER, Action::SAVE_AND_CONTINUE, Action::SAVE_AND_RETURN] as $action) {
             $subject = ['entity' => $this->createEntityDto(Event::class, $event), 'action' => $action];
             $this->assertSame(
                 VoterInterface::ACCESS_GRANTED,
-                $voter->vote($token, $subject, [Permission::EA_EXECUTE_ACTION]),
+                $voter->vote($this->createToken($user), $subject, [Permission::EA_EXECUTE_ACTION]),
+            );
+        }
+    }
+
+    /**
+     * Denies save actions to an organization editor for an event owned by another organization.
+     */
+    public function testOrganizationEditorCannotSaveOtherOrgEvent(): void
+    {
+        $voter = new EventVoter($this->createSecurity([UserRoles::ROLE_ORGANIZATION_EDITOR->value]));
+
+        $userOrg = new Organization();
+        $otherOrg = new Organization();
+        $user = new User();
+        $user->addOrganization($userOrg);
+
+        $event = new Event();
+        $event->setOrganization($otherOrg);
+
+        foreach ([Action::SAVE_AND_ADD_ANOTHER, Action::SAVE_AND_CONTINUE, Action::SAVE_AND_RETURN] as $action) {
+            $subject = ['entity' => $this->createEntityDto(Event::class, $event), 'action' => $action];
+            $this->assertSame(
+                VoterInterface::ACCESS_DENIED,
+                $voter->vote($this->createToken($user), $subject, [Permission::EA_EXECUTE_ACTION]),
+                sprintf('Expected save action %s to be denied for another organization', $action),
             );
         }
     }


### PR DESCRIPTION
Closes the deferred authorization gaps from the #76 review: the admin CRUD voters abstained on EasyAdmin's null-entity `NEW` subject, so the `New` page was only *hidden* in the UI (`configureActions()`), not enforced at the URL level — any authenticated user could `GET /admin/<entity>/new`.

## Fix (TDD, per voter)

- **`supports()`** now matches on `$subject['entityFqcn']` (which EA always sets, even when `entity` is null for INDEX/NEW), falling back to the DTO's fqcn.
- **`voteOnAttribute()`** handles `NEW` (and INDEX/DETAIL) *before* dereferencing the entity instance, and gates `NEW` per the existing per-voter policy:
  - Organization / Location / Address → `ROLE_EDITOR`
  - Event → `ROLE_ORGANIZATION_EDITOR`
  - Tag → open to any authenticated user (unchanged)
- **`EventVoter` SAVE scoping**: the save-action grant now mirrors the edit path — editors save any event, organization editors only within their own organization(s) (closes the cross-org SAVE gap).

## Tests (red → green)

- Un-skipped `OrganizationCrudTest::testOrgAdminCannotCreateOrganization` (was RED: org-admin got 200 on `/organization/new`).
- Added `EventVoterTest::testOrganizationEditorCannotSaveOtherOrgEvent` and tightened `testSaveActionsAllowedForOrganizationEditor` to the own-org case.
- Added NEW-denial rows to `CrudSmokeTest` (org-admin denied Address/Location `New`; tag `New` stays open).
- The previously "dead-path" INDEX/NEW voter unit tests now exercise real enforcement.

## Docs

- Added a **Roles and permissions** matrix to the README covering every EasyAdmin entity (Organization, Event, Location, Address, Tag, Vocabulary, Feed, Feed item, User) and the three enforcement mechanisms (voters, controller `setPermission`, field/disabled actions). Vocabularies and feeds are left admin/super-admin-only as-is.

## Verification

- `task test` — 132 passing, 0 skips (down from the earlier documented skips).
- `vendor/bin/phpstan analyse` — clean.
- `vendor/bin/php-cs-fixer check` — clean.

Follows #85 (feed-guard-before-SAVE). Note: Vocabulary/Feed/FeedItem already enforce their actions via `setPermission`/disabled actions, so they never had the null-entity gap.