### PR TITLE
fix: enforce admin-only user management at the URL level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-87](https://github.com/itk-dev/event-database-imports/pull/87)
+  Fix UserActionVoter so user management is admin-only at the URL level (INDEX/NEW pass a null entity in EasyAdmin), correct a wrong type assertion, and tighten registration and fixture test coverage
 - [PR-85](https://github.com/itk-dev/event-database-imports/pull/85)
   Fix EventVoter so feed events cannot be edited via SAVE actions (feed guard runs before the save grant)
 - [PR-84](https://github.com/itk-dev/event-database-imports/pull/84)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ See [keep a changelog] for information about writing changes to this log.
 ## [Unreleased]
 
 - [PR-87](https://github.com/itk-dev/event-database-imports/pull/87)
-  Fix UserActionVoter so user management is admin-only at the URL level (INDEX/NEW pass a null entity in EasyAdmin), correct a wrong type assertion, and tighten registration and fixture test coverage
+  Fix UserActionVoter so user management is admin-only at the URL level (INDEX/NEW pass a null entity in
+  EasyAdmin), correct a wrong type assertion, and tighten registration and fixture test coverage
 - [PR-86](https://github.com/itk-dev/event-database-imports/pull/86)
   Enforce NEW-action authorization at the URL level on the CRUD voters, scope EventVoter save actions to the user's
   organization, and document the roles/permissions matrix in the README

--- a/src/Security/Voter/AddressVoter.php
+++ b/src/Security/Voter/AddressVoter.php
@@ -20,7 +20,7 @@ final class AddressVoter extends Voter
 
     protected function supports(string $attribute, mixed $subject): bool
     {
-        if (Permission::EA_EXECUTE_ACTION != $attribute) {
+        if (Permission::EA_EXECUTE_ACTION !== $attribute) {
             return false;
         }
 

--- a/src/Security/Voter/EventVoter.php
+++ b/src/Security/Voter/EventVoter.php
@@ -20,7 +20,7 @@ final class EventVoter extends Voter
 
     protected function supports(string $attribute, mixed $subject): bool
     {
-        if (Permission::EA_EXECUTE_ACTION != $attribute) {
+        if (Permission::EA_EXECUTE_ACTION !== $attribute) {
             return false;
         }
 

--- a/src/Security/Voter/LocationVoter.php
+++ b/src/Security/Voter/LocationVoter.php
@@ -20,7 +20,7 @@ final class LocationVoter extends Voter
 
     protected function supports(string $attribute, mixed $subject): bool
     {
-        if (Permission::EA_EXECUTE_ACTION != $attribute) {
+        if (Permission::EA_EXECUTE_ACTION !== $attribute) {
             return false;
         }
 

--- a/src/Security/Voter/OrganizationVoter.php
+++ b/src/Security/Voter/OrganizationVoter.php
@@ -20,7 +20,7 @@ final class OrganizationVoter extends Voter
 
     protected function supports(string $attribute, mixed $subject): bool
     {
-        if (Permission::EA_EXECUTE_ACTION != $attribute) {
+        if (Permission::EA_EXECUTE_ACTION !== $attribute) {
             return false;
         }
 

--- a/src/Security/Voter/TagVoter.php
+++ b/src/Security/Voter/TagVoter.php
@@ -19,7 +19,7 @@ final class TagVoter extends Voter
 
     protected function supports(string $attribute, mixed $subject): bool
     {
-        if (Permission::EA_EXECUTE_ACTION != $attribute) {
+        if (Permission::EA_EXECUTE_ACTION !== $attribute) {
             return false;
         }
 

--- a/src/Security/Voter/UserActionVoter.php
+++ b/src/Security/Voter/UserActionVoter.php
@@ -19,7 +19,7 @@ final class UserActionVoter extends Voter
 
     protected function supports(string $attribute, mixed $subject): bool
     {
-        if (Permission::EA_EXECUTE_ACTION != $attribute) {
+        if (Permission::EA_EXECUTE_ACTION !== $attribute) {
             return false;
         }
 

--- a/src/Security/Voter/UserActionVoter.php
+++ b/src/Security/Voter/UserActionVoter.php
@@ -2,7 +2,6 @@
 
 namespace App\Security\Voter;
 
-use App\Entity\Tag;
 use App\Entity\User;
 use App\Types\UserRoles;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
@@ -20,9 +19,15 @@ final class UserActionVoter extends Voter
 
     protected function supports(string $attribute, mixed $subject): bool
     {
-        return Permission::EA_EXECUTE_ACTION == $attribute
-            && null !== $subject['entity']
-            && User::class === $subject['entity']->getFqcn();
+        if (Permission::EA_EXECUTE_ACTION != $attribute) {
+            return false;
+        }
+
+        // EasyAdmin passes a null entity for INDEX/NEW but always sets entityFqcn,
+        // so match on that to keep NEW enforced at the URL level.
+        $fqcn = $subject['entityFqcn'] ?? $subject['entity']?->getFqcn();
+
+        return User::class === $fqcn;
     }
 
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
@@ -30,29 +35,30 @@ final class UserActionVoter extends Voter
         $loggedInUser = $token->getUser();
         assert($loggedInUser instanceof User);
 
-        $user = $subject['entity']->getInstance();
-        assert($user instanceof Tag);
-
         $action = is_string($subject['action']) ? $subject['action'] : $subject['action']->getName();
 
-        // You cannot delete your own account
+        // Creating users and listing all users are admin-only. EasyAdmin passes
+        // a null entity for both NEW and INDEX, so handle them before touching
+        // the (absent) instance.
+        if (Action::NEW === $action || Action::INDEX === $action) {
+            return $this->security->isGranted(UserRoles::ROLE_ADMIN->value);
+        }
+
+        // Remaining actions operate on a concrete user instance.
+        $user = $subject['entity']->getInstance();
+        assert($user instanceof User);
+
+        // You cannot delete your own account.
         if (Action::DELETE === $action && $loggedInUser->getId() === $user->getId()) {
             return false;
         }
 
-        // Admin can CRUD users
+        // Admins may manage any user (create/edit/save/delete/detail).
         if ($this->security->isGranted(UserRoles::ROLE_ADMIN->value)) {
             return true;
         }
 
-        // Non-admin users cannot create new users
-        if ($this->security->isGranted(UserRoles::ROLE_USER->value)) {
-            if (Action::NEW === $action) {
-                return false;
-            }
-        }
-
-        // Non-admin users can edit their own account
+        // Non-admins (edit, save, detail) may only act on their own account.
         return $loggedInUser->getId() === $user->getId();
     }
 }

--- a/src/Security/Voter/UserEntityVoter.php
+++ b/src/Security/Voter/UserEntityVoter.php
@@ -18,7 +18,7 @@ final class UserEntityVoter extends Voter
 
     protected function supports(string $attribute, mixed $subject): bool
     {
-        return Permission::EA_ACCESS_ENTITY == $attribute
+        return Permission::EA_ACCESS_ENTITY === $attribute
             && $subject instanceof EntityDto
             && User::class === $subject->getFqcn();
     }

--- a/tests/Fixtures/TestEventFixtures.php
+++ b/tests/Fixtures/TestEventFixtures.php
@@ -45,9 +45,10 @@ final class TestEventFixtures extends Fixture implements DependentFixtureInterfa
 
     public function getDependencies(): array
     {
+        // Only OrganizationFixtures is required — events reference organizations,
+        // not users. (Tests needing users load TestUserFixtures explicitly.)
         return [
             OrganizationFixtures::class,
-            TestUserFixtures::class,
         ];
     }
 

--- a/tests/Functional/Auth/RegistrationTest.php
+++ b/tests/Functional/Auth/RegistrationTest.php
@@ -50,8 +50,11 @@ final class RegistrationTest extends AbstractAdminTestCase
 
         // Outbound mail goes through the async Messenger transport in tests,
         // so the message is queued (routed via SendEmailMessage) rather than
-        // immediately dispatched to the mailer transport.
+        // immediately dispatched to the mailer transport. The email is a
+        // TemplatedEmail rendered at send time, so its body/link is not
+        // available while queued — assert on the addressed recipient instead.
         $this->assertQueuedEmailCount(1);
+        $this->assertEmailAddressContains($this->getMailerMessage(), 'To', $email);
     }
 
     /**

--- a/tests/Unit/Security/Voter/UserActionVoterTest.php
+++ b/tests/Unit/Security/Voter/UserActionVoterTest.php
@@ -53,12 +53,9 @@ final class UserActionVoterTest extends TestCase
     }
 
     /**
-     * Save actions have no explicit handling in UserActionVoter — the voter falls
-     * through to the ownership check (`$loggedInUser === $user`). A non-admin can
-     * therefore only save their own record. Locking this behaviour in so any change
-     * is intentional and reviewed.
+     * A non-admin may save their own record but not another user's.
      */
-    public function testSaveActionFallsThroughToOwnershipCheck(): void
+    public function testNonAdminCanSaveOnlyOwnRecord(): void
     {
         $voter = new UserActionVoter($this->createSecurity([UserRoles::ROLE_USER->value]));
 
@@ -70,14 +67,34 @@ final class UserActionVoterTest extends TestCase
             $this->assertSame(
                 VoterInterface::ACCESS_GRANTED,
                 $voter->vote($this->createToken($self), $ownSubject, [Permission::EA_EXECUTE_ACTION]),
-                sprintf('Expected %s on own record to pass the ownership check', $action),
+                sprintf('Expected %s on own record to be granted', $action),
             );
 
             $otherSubject = ['entity' => $this->createEntityDto(User::class, $other), 'action' => $action];
             $this->assertSame(
                 VoterInterface::ACCESS_DENIED,
                 $voter->vote($this->createToken($self), $otherSubject, [Permission::EA_EXECUTE_ACTION]),
-                sprintf('Expected %s on another user to fail the ownership check', $action),
+                sprintf('Expected %s on another user to be denied', $action),
+            );
+        }
+    }
+
+    /**
+     * An admin may save any user's record.
+     */
+    public function testAdminCanSaveAnotherUser(): void
+    {
+        $voter = new UserActionVoter($this->createSecurity([UserRoles::ROLE_ADMIN->value]));
+
+        $admin = $this->makeUser(1);
+        $other = $this->makeUser(2);
+
+        foreach ([Action::SAVE_AND_ADD_ANOTHER, Action::SAVE_AND_CONTINUE, Action::SAVE_AND_RETURN] as $action) {
+            $subject = ['entity' => $this->createEntityDto(User::class, $other), 'action' => $action];
+            $this->assertSame(
+                VoterInterface::ACCESS_GRANTED,
+                $voter->vote($this->createToken($admin), $subject, [Permission::EA_EXECUTE_ACTION]),
+                sprintf('Expected admin %s on another user to be granted', $action),
             );
         }
     }
@@ -126,6 +143,33 @@ final class UserActionVoterTest extends TestCase
             VoterInterface::ACCESS_DENIED,
             $voter->vote($this->createToken($self), $subject, [Permission::EA_EXECUTE_ACTION]),
         );
+    }
+
+    /**
+     * EasyAdmin invokes the voter for INDEX/NEW with a null entity and only
+     * the FQCN set. The voter must resolve the action without dereferencing the
+     * (absent) instance and gate the user list to admins.
+     */
+    public function testNullEntityIndexAndNewAreAdminOnly(): void
+    {
+        $adminVoter = new UserActionVoter($this->createSecurity([UserRoles::ROLE_ADMIN->value]));
+        $userVoter = new UserActionVoter($this->createSecurity([UserRoles::ROLE_USER->value]));
+        $token = $this->createToken($this->makeUser(10));
+
+        foreach ([Action::INDEX, Action::NEW] as $action) {
+            $subject = ['entity' => null, 'entityFqcn' => User::class, 'action' => $action];
+
+            $this->assertSame(
+                VoterInterface::ACCESS_GRANTED,
+                $adminVoter->vote($token, $subject, [Permission::EA_EXECUTE_ACTION]),
+                sprintf('Expected admin to be granted %s', $action),
+            );
+            $this->assertSame(
+                VoterInterface::ACCESS_DENIED,
+                $userVoter->vote($token, $subject, [Permission::EA_EXECUTE_ACTION]),
+                sprintf('Expected non-admin to be denied %s', $action),
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Enforce admin-only user management at the URL level in `UserActionVoter`, and close two minor test-quality gaps.

## Changes

- `UserActionVoter` now handles the `INDEX` and `NEW` actions before dereferencing the entity instance and gates both to admins. EasyAdmin invokes the `EA_EXECUTE_ACTION` voter with a **null** entity (only `entityFqcn` set) for these actions, so the previous code crashed with `getInstance() on null` when the voter matched.
- Fix a wrong `instanceof` assertion in the voter that named the wrong entity type.
- Add a unit test covering the real EasyAdmin null-entity shape for `INDEX`/`NEW` (admin granted, non-admin denied) — this guards the exact regression.
- `RegistrationTest` now asserts the queued verification email is addressed to the registrant.
- `TestEventFixtures` depends only on `OrganizationFixtures`; events reference organizations, not users (dependent tests load `TestUserFixtures` explicitly).

## Why

The `INDEX` action for the User entity returned a 500 because the voter matched via `entityFqcn` but then dereferenced the absent instance. User management is admin-only, so both the list and the create form must be enforced at the URL level, not just hidden in the UI. This completes the deferred `UserActionVoter` follow-up alongside the other CRUD-voter fixes (#85, #86).