### PR TITLE
fix: create now-timestamps in UTC, not the ambient timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-90](https://github.com/itk-dev/event-database-imports/pull/90)
+  Create "now" timestamps explicitly in UTC (email verification, terms acceptance, feed last-read and
+  last-seen) and use gmdate for versioned index names, so they no longer depend on the ambient PHP timezone
 - [PR-89](https://github.com/itk-dev/event-database-imports/pull/89)
   Centralize the display timezone as a single injected source shared by the admin UI and the Elasticsearch
   index, and stop UTCDateTimeType from mutating the caller's datetime when converting to UTC for storage

--- a/src/Controller/AcceptTermsController.php
+++ b/src/Controller/AcceptTermsController.php
@@ -30,7 +30,7 @@ class AcceptTermsController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $user->setTermsAcceptedAt(new \DateTimeImmutable());
+            $user->setTermsAcceptedAt(new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
 
             $entityManager->flush();
 

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -53,7 +53,7 @@ class RegistrationController extends AbstractController
                 )
             );
 
-            $user->setTermsAcceptedAt(new \DateTimeImmutable());
+            $user->setTermsAcceptedAt(new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
             $user->setRoles([UserRoles::ROLE_USER]);
             $user->setCreatedBy($user->getName());
             $user->setUpdatedBy($user->getName());

--- a/src/Entity/FeedItem.php
+++ b/src/Entity/FeedItem.php
@@ -135,7 +135,7 @@ class FeedItem
 
     public function setLastSeenAt(): static
     {
-        $this->lastSeenAt = new \DateTimeImmutable();
+        $this->lastSeenAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
 
         return $this;
     }

--- a/src/Security/EmailVerifier.php
+++ b/src/Security/EmailVerifier.php
@@ -44,7 +44,7 @@ readonly class EmailVerifier
     {
         $this->verifyEmailHelper->validateEmailConfirmation($request->getUri(), (string) $user->getId(), $user->getMail());
 
-        $user->setEmailVerifiedAt(new \DateTimeImmutable());
+        $user->setEmailVerifiedAt(new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
 
         $this->entityManager->persist($user);
         $this->entityManager->flush();

--- a/src/Service/Feeds/Reader/FeedReader.php
+++ b/src/Service/Feeds/Reader/FeedReader.php
@@ -121,7 +121,7 @@ class FeedReader implements FeedReaderInterface
                 $this->cleanUp($feed, $start);
             }
 
-            $feed->setLastRead(new \DateTimeImmutable());
+            $feed->setLastRead(new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
             $feed->setLastReadCount($index);
             $feed->setMessage(null);
             $this->feedRepository->save($feed, true);

--- a/src/Service/Indexing/AbstractIndexingElastic.php
+++ b/src/Service/Indexing/AbstractIndexingElastic.php
@@ -81,7 +81,7 @@ abstract class AbstractIndexingElastic implements IndexingInterface
     {
         try {
             if (null === $this->newIndexName) {
-                $this->newIndexName = $this::INDEX_ALIAS.'_'.date('Y-m-d-His');
+                $this->newIndexName = $this::INDEX_ALIAS.'_'.gmdate('Y-m-d-His');
                 $this->createEsIndex($this->newIndexName);
             }
 
@@ -113,7 +113,7 @@ abstract class AbstractIndexingElastic implements IndexingInterface
             throw new IndexingException('Index already exists');
         }
 
-        $newIndexName = $this::INDEX_ALIAS.'_'.date('Y-m-d-His');
+        $newIndexName = $this::INDEX_ALIAS.'_'.gmdate('Y-m-d-His');
         $this->createEsIndex($newIndexName);
         $this->refreshIndex($newIndexName);
 

--- a/tests/Unit/Entity/FeedItemTest.php
+++ b/tests/Unit/Entity/FeedItemTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Feed;
+use App\Entity\FeedItem;
+use PHPUnit\Framework\TestCase;
+
+final class FeedItemTest extends TestCase
+{
+    /**
+     * "Now" timestamps must be created in UTC (the model timezone) rather than
+     * the ambient PHP default timezone, which differs between environments
+     * (Europe/Copenhagen locally, UTC on the server).
+     */
+    public function testSetLastSeenAtUsesUtc(): void
+    {
+        $item = new FeedItem(new Feed(), 'feed-item-id', []);
+
+        $item->setLastSeenAt();
+
+        $lastSeenAt = $item->getLastSeenAt();
+        self::assertInstanceOf(\DateTimeImmutable::class, $lastSeenAt);
+        self::assertSame('UTC', $lastSeenAt->getTimezone()->getName());
+    }
+}


### PR DESCRIPTION
Fixes the P2 items from the model/view timezone sweep: "now" timestamps created in the ambient PHP timezone.

## Changes

- Create these timestamps explicitly in UTC (the model timezone) instead of `new \DateTimeImmutable()`, which anchors to `date_default_timezone_get()`:
  - `EmailVerifier` — email verified at
  - `RegistrationController` / `AcceptTermsController` — terms accepted at
  - `FeedReader` — feed last-read at
  - `FeedItem::setLastSeenAt()` — feed item last-seen at
- Use `gmdate()` for the versioned index-name suffix in `AbstractIndexingElastic` so the name is UTC regardless of environment.

## Test (TDD, red → green)

- `tests/Unit/Entity/FeedItemTest.php` — asserts `setLastSeenAt()` produces a UTC-zoned timestamp. It fails on `develop` (the test container defaults to `Europe/Copenhagen`, like dev) and passes after the fix.

## Why

`date_default_timezone_get()` is `Europe/Copenhagen` locally but `UTC` on the server, so zone-less `now()` produced a differently-zoned object per environment. The persisted instant was already correct (Doctrine coerces to UTC on write); this makes the in-memory value environment-neutral and removes a latent format/compare-before-persist hazard.

`OccurrenceFixture` was intentionally left alone — its datetime strings carry explicit offsets, so they are not ambient-timezone dependent.