### PR TITLE
fix: correct Danish admin translation strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-91](https://github.com/itk-dev/event-database-imports/pull/91)
+  Correct Danish admin translations: the delete-confirmation modal now reads "… vil slette?" instead of
+  interpolating the imperative action label, and translate the leftover English login-page strings
+
 - [PR-89](https://github.com/itk-dev/event-database-imports/pull/89)
   Centralize the display timezone as a single injected source shared by the admin UI and the Elasticsearch
   index, and stop UTCDateTimeType from mutating the caller's datetime when converting to UTC for storage

--- a/translations/EasyAdminBundle.da.xlf
+++ b/translations/EasyAdminBundle.da.xlf
@@ -105,6 +105,10 @@
         <source>delete_modal.content</source>
         <target>Denne operation kan ikke fortrydes.</target>
       </trans-unit>
+      <trans-unit id="aCnfMdlT" resname="action_confirmation_modal.title">
+        <source>action_confirmation_modal.title</source>
+        <target>Er du sikker på, at du vil slette?</target>
+      </trans-unit>
       <trans-unit id="VH1tHkH" resname="filter.title">
         <source>filter.title</source>
         <target>Filtre</target>
@@ -151,15 +155,15 @@
       </trans-unit>
       <trans-unit id="iFP0IOu" resname="login_page.username">
         <source>login_page.username</source>
-        <target>Username</target>
+        <target>Brugernavn</target>
       </trans-unit>
       <trans-unit id="uxJWiMn" resname="login_page.password">
         <source>login_page.password</source>
-        <target>Password</target>
+        <target>Adgangskode</target>
       </trans-unit>
       <trans-unit id="eiGmhDt" resname="login_page.sign_in">
         <source>login_page.sign_in</source>
-        <target>Sign in</target>
+        <target>Log ind</target>
       </trans-unit>
       <trans-unit id="IsDUuMi" resname="login_page.forgot_password">
         <source>login_page.forgot_password</source>


### PR DESCRIPTION
Corrects the ungrammatical delete-confirmation text noticed in the admin, plus a few untranslated leftovers.

## Changes

- **Delete confirmation modal.** EasyAdmin's `action_confirmation_modal.title` is "Er du sikker på, at du vil %action_name%?", and the JS replaces `%action_name%` with the action's button label — for delete that's the imperative "Slet", giving the ungrammatical **"Er du sikker på, at du vil Slet?"**. Override the key in `translations/EasyAdminBundle.da.xlf` with the infinitive: **"Er du sikker på, at du vil slette?"**. Delete is the only confirmable action in this admin, so dropping the placeholder is safe (verified in the browser).
- **Login-page leftovers.** Translated three strings that were still English in the Danish file: `login_page.username` → "Brugernavn", `login_page.password` → "Adgangskode", `login_page.sign_in` → "Log ind" (consistent with the existing "Glemt din adgangskode?" / "Log ind" usage).

## Verification

- `bin/console lint:xliff` passes.
- Confirmed live via the running admin: the delete modal now renders "Er du sikker på, at du vil slette?".