### PR TITLE
test: characterize EasyAdmin admin behavior ahead of 4→5 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-92](https://github.com/itk-dev/event-database-imports/pull/92)
+  Add EasyAdmin characterization tests ahead of the 4→5 upgrade: CRUD detail/edit render matrix, create/edit
+  form round-trips, the login accept-terms and email-verified gates, and feed/ADR-007 action authorization
+
 - [PR-91](https://github.com/itk-dev/event-database-imports/pull/91)
   Correct Danish admin translations: the delete-confirmation modal now reads "… vil slette?" instead of
   interpolating the imperative action label, and translate the leftover English login-page strings

--- a/tests/Functional/Admin/AdminActionAuthorizationTest.php
+++ b/tests/Functional/Admin/AdminActionAuthorizationTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Admin;
+
+use App\Controller\Admin\EventCrudController;
+use App\Controller\Admin\FeedCrudController;
+use App\DataFixtures\OrganizationFixtures;
+use App\Entity\Event;
+use App\Entity\Feed;
+use App\Entity\Organization;
+use App\Tests\Fixtures\TestUserFixtures;
+use App\Tests\Functional\AbstractAdminTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+
+/**
+ * Characterizes action-level authorization that only exists as UI/HTTP behavior
+ * today: Feed mutations are super-admin only, and feed-imported events are
+ * read-only (ADR 007). The feed-event guard is unit-tested on EventVoter, but
+ * not asserted through the actual admin URL — this pins that behavior before
+ * the EasyAdmin 5 upgrade, which touches how permissions gate actions.
+ */
+final class AdminActionAuthorizationTest extends AbstractAdminTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadFixtures([
+            OrganizationFixtures::class,
+            TestUserFixtures::class,
+        ]);
+    }
+
+    private function entityManager(): EntityManagerInterface
+    {
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+        self::assertInstanceOf(EntityManagerInterface::class, $em);
+
+        return $em;
+    }
+
+    private function createFeed(): Feed
+    {
+        $feed = new Feed();
+        $feed->setName('Characterization Feed')
+            ->setEnabled(true)
+            ->setConfiguration([]);
+        $this->entityManager()->persist($feed);
+
+        return $feed;
+    }
+
+    /**
+     * A plain admin (not super-admin) cannot reach the Feed edit action.
+     */
+    public function testAdminCannotEditFeed(): void
+    {
+        $feed = $this->createFeed();
+        $this->entityManager()->flush();
+        $id = $feed->getId();
+        $this->entityManager()->clear();
+
+        $this->loginAs(TestUserFixtures::ADMIN_EMAIL);
+        $this->client->request('GET', $this->adminUrl(FeedCrudController::class, Action::EDIT, ['entityId' => $id]));
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    /**
+     * A super-admin can reach the Feed edit action (the counterpart to the above).
+     */
+    public function testSuperAdminCanEditFeed(): void
+    {
+        $feed = $this->createFeed();
+        $this->entityManager()->flush();
+        $id = $feed->getId();
+        $this->entityManager()->clear();
+
+        $this->loginAs(TestUserFixtures::SUPER_ADMIN_EMAIL);
+        $this->client->request('GET', $this->adminUrl(FeedCrudController::class, Action::EDIT, ['entityId' => $id]));
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    /**
+     * A feed-imported event is read-only: even an admin is denied the edit
+     * action (ADR 007, enforced by EventVoter's feed guard).
+     */
+    public function testFeedImportedEventEditIsDenied(): void
+    {
+        $org = $this->entityManager()->getRepository(Organization::class)->findOneBy([]);
+        self::assertInstanceOf(Organization::class, $org);
+
+        $feed = $this->createFeed();
+
+        $event = new Event();
+        $event->setTitle('Imported event')
+            ->setDescription('desc')
+            ->setUpdatedBy('feed')
+            ->setEditable(false)
+            ->setOrganization($org)
+            ->setFeed($feed);
+        $this->entityManager()->persist($event);
+        $this->entityManager()->flush();
+        $id = $event->getId();
+        $this->entityManager()->clear();
+
+        $this->loginAs(TestUserFixtures::ADMIN_EMAIL);
+        $this->client->request('GET', $this->adminUrl(EventCrudController::class, Action::EDIT, ['entityId' => $id]));
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+}

--- a/tests/Functional/Admin/CrudRenderMatrixTest.php
+++ b/tests/Functional/Admin/CrudRenderMatrixTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Admin;
+
+use App\Controller\Admin\AddressCrudController;
+use App\Controller\Admin\EmbedOccurrenceCrudController;
+use App\Controller\Admin\EventCrudController;
+use App\Controller\Admin\FeedCrudController;
+use App\Controller\Admin\LocationCrudController;
+use App\Controller\Admin\OrganizationCrudController;
+use App\Controller\Admin\TagCrudController;
+use App\Controller\Admin\UserCrudController;
+use App\Controller\Admin\VocabularyCrudController;
+use App\DataFixtures\AddressFixture;
+use App\DataFixtures\DailyOccurrenceFixture;
+use App\DataFixtures\EventFixture;
+use App\DataFixtures\FeedFixtures;
+use App\DataFixtures\LocationFixture;
+use App\DataFixtures\OccurrenceFixture;
+use App\DataFixtures\TagsFixtures;
+use App\Entity\Address;
+use App\Entity\Event;
+use App\Entity\Feed;
+use App\Entity\Location;
+use App\Entity\Occurrence;
+use App\Entity\Organization;
+use App\Entity\Tag;
+use App\Entity\User;
+use App\Entity\Vocabulary;
+use App\Tests\Fixtures\TestUserFixtures;
+use App\Tests\Functional\AbstractAdminTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+
+/**
+ * Characterizes that every EasyAdmin DETAIL and EDIT page renders for a
+ * super-admin against realistic (dev-fixture) data. Existing tests only cover
+ * INDEX/NEW for most controllers, so a field-configurator or template
+ * regression on DETAIL/EDIT would be invisible today. This is the broad safety
+ * net for the EasyAdmin 5 upgrade, which reworks field rendering and templates.
+ */
+final class CrudRenderMatrixTest extends AbstractAdminTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadFixtures([
+            AddressFixture::class,
+            LocationFixture::class,
+            TagsFixtures::class,
+            FeedFixtures::class,
+            EventFixture::class,
+            OccurrenceFixture::class,
+            DailyOccurrenceFixture::class,
+            TestUserFixtures::class,
+        ]);
+    }
+
+    private function firstId(string $entityClass): int|string
+    {
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+        self::assertInstanceOf(EntityManagerInterface::class, $em);
+        $entity = $em->getRepository($entityClass)->findOneBy([]);
+        self::assertNotNull($entity, sprintf('Expected at least one %s from fixtures', $entityClass));
+
+        $id = $em->getUnitOfWork()->getSingleIdentifierValue($entity);
+        self::assertNotNull($id);
+
+        return $id;
+    }
+
+    /**
+     * @return iterable<string, array{class-string, class-string, list<string>}>
+     */
+    public static function crudProvider(): iterable
+    {
+        // [CRUD controller, entity class, actions to render]
+        yield 'event' => [EventCrudController::class, Event::class, [Action::DETAIL, Action::EDIT]];
+        yield 'organization' => [OrganizationCrudController::class, Organization::class, [Action::DETAIL, Action::EDIT]];
+        yield 'location' => [LocationCrudController::class, Location::class, [Action::DETAIL, Action::EDIT]];
+        yield 'address' => [AddressCrudController::class, Address::class, [Action::DETAIL, Action::EDIT]];
+        yield 'tag' => [TagCrudController::class, Tag::class, [Action::DETAIL, Action::EDIT]];
+        yield 'vocabulary' => [VocabularyCrudController::class, Vocabulary::class, [Action::DETAIL, Action::EDIT]];
+        yield 'feed' => [FeedCrudController::class, Feed::class, [Action::DETAIL, Action::EDIT]];
+        yield 'user' => [UserCrudController::class, User::class, [Action::DETAIL, Action::EDIT]];
+        yield 'occurrence' => [EmbedOccurrenceCrudController::class, Occurrence::class, [Action::DETAIL, Action::EDIT]];
+    }
+
+    /**
+     * @param class-string $crudControllerFqcn
+     * @param class-string $entityClass
+     * @param list<string> $actions
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('crudProvider')]
+    public function testDetailAndEditRender(string $crudControllerFqcn, string $entityClass, array $actions): void
+    {
+        // Super-admin can reach every action (incl. super-admin-only Feed edit).
+        $this->loginAs(TestUserFixtures::SUPER_ADMIN_EMAIL);
+        $id = $this->firstId($entityClass);
+
+        foreach ($actions as $action) {
+            $this->client->request('GET', $this->adminUrl($crudControllerFqcn, $action, ['entityId' => $id]));
+            $this->assertResponseIsSuccessful(sprintf('%s %s should render', $crudControllerFqcn, $action));
+        }
+    }
+}

--- a/tests/Functional/Admin/CrudWriteRoundTripTest.php
+++ b/tests/Functional/Admin/CrudWriteRoundTripTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Admin;
+
+use App\Controller\Admin\EventCrudController;
+use App\Controller\Admin\TagCrudController;
+use App\DataFixtures\OrganizationFixtures;
+use App\Entity\Event;
+use App\Entity\Occurrence;
+use App\Entity\Tag;
+use App\Tests\Fixtures\TestEventFixtures;
+use App\Tests\Fixtures\TestUserFixtures;
+use App\Tests\Functional\AbstractAdminTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+
+/**
+ * Characterizes the EasyAdmin write path end-to-end: creating and editing
+ * entities by submitting the generated forms, plus the occurrence cascade that
+ * the delete action relies on. Existing admin tests only assert GET access, so
+ * this pins the form-handling / persistence behavior before the EasyAdmin 5
+ * upgrade (which changes form rendering and field configurators).
+ *
+ * Delete is driven by EasyAdmin's JavaScript confirmation modal and cannot be
+ * submitted headlessly via BrowserKit, so the delete-cascade behavior is
+ * characterized at the ORM level instead.
+ */
+final class CrudWriteRoundTripTest extends AbstractAdminTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadFixtures([
+            OrganizationFixtures::class,
+            TestUserFixtures::class,
+            TestEventFixtures::class,
+        ]);
+    }
+
+    private function entityManager(): EntityManagerInterface
+    {
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+        self::assertInstanceOf(EntityManagerInterface::class, $em);
+
+        return $em;
+    }
+
+    /**
+     * Submitting the "new" form creates the entity.
+     */
+    public function testCreateTagViaNewForm(): void
+    {
+        $this->loginAs(TestUserFixtures::ADMIN_EMAIL);
+
+        $crawler = $this->client->request('GET', $this->adminUrl(TagCrudController::class, Action::NEW));
+        $this->assertResponseIsSuccessful();
+
+        // The slug field is disabled and auto-generated from the name via a
+        // PrePersist hook, so only the name is submitted.
+        $form = $crawler->filter('form[name="Tag"]')->form();
+        $this->client->submit($form, [
+            'Tag[name]' => 'Characterization Tag',
+        ]);
+
+        $this->assertResponseRedirects();
+
+        $this->entityManager()->clear();
+        $tag = $this->entityManager()->getRepository(Tag::class)->findOneBy(['name' => 'Characterization Tag']);
+        self::assertInstanceOf(Tag::class, $tag);
+        self::assertNotEmpty($tag->getSlug(), 'The slug must be auto-generated on persist');
+    }
+
+    /**
+     * Submitting the "edit" form updates the entity.
+     */
+    public function testEditTagViaEditForm(): void
+    {
+        $tag = new Tag();
+        $tag->setName('Before')->setSlug(); // slug derived from name
+        $this->entityManager()->persist($tag);
+        $this->entityManager()->flush();
+        $id = $tag->getId();
+        // Detach so the edit request re-hydrates from the DB (as a real request
+        // would), rather than reusing the in-memory Gedmo-stamped timestamp.
+        $this->entityManager()->clear();
+
+        $this->loginAs(TestUserFixtures::ADMIN_EMAIL);
+
+        $crawler = $this->client->request('GET', $this->adminUrl(TagCrudController::class, Action::EDIT, ['entityId' => $id]));
+        $this->assertResponseIsSuccessful();
+
+        $form = $crawler->filter('form[name="Tag"]')->form();
+        $this->client->submit($form, ['Tag[name]' => 'After']);
+
+        $this->assertResponseRedirects();
+
+        $this->entityManager()->clear();
+        $updated = $this->entityManager()->getRepository(Tag::class)->find($id);
+        self::assertInstanceOf(Tag::class, $updated);
+        self::assertSame('After', $updated->getName());
+    }
+
+    /**
+     * Editing an event through the form persists the change and stamps the
+     * acting user via the blame mechanism.
+     */
+    public function testEditEventTitleViaEditFormStampsUpdatedBy(): void
+    {
+        $event = $this->entityManager()->getRepository(Event::class)->findOneBy(['title' => 'Org A Event 1']);
+        self::assertInstanceOf(Event::class, $event);
+        $id = $event->getId();
+
+        $this->loginAs(TestUserFixtures::ADMIN_EMAIL);
+
+        $crawler = $this->client->request('GET', $this->adminUrl(EventCrudController::class, Action::EDIT, ['entityId' => $id]));
+        $this->assertResponseIsSuccessful();
+
+        $form = $crawler->filter('form[name="Event"]')->form();
+        $this->client->submit($form, ['Event[title]' => 'Org A Event 1 (edited)']);
+
+        $this->assertResponseRedirects();
+
+        $this->entityManager()->clear();
+        $updated = $this->entityManager()->getRepository(Event::class)->find($id);
+        self::assertInstanceOf(Event::class, $updated);
+        self::assertSame('Org A Event 1 (edited)', $updated->getTitle());
+        self::assertSame(TestUserFixtures::ADMIN_EMAIL, $updated->getUpdatedBy());
+    }
+
+    /**
+     * Removing an event cascades to its occurrences — the data-integrity
+     * behavior the admin delete action depends on.
+     */
+    public function testDeletingEventRemovesItsOccurrences(): void
+    {
+        $em = $this->entityManager();
+        $org = $this->entityManager()->getRepository(\App\Entity\Organization::class)->findOneBy([]);
+        self::assertNotNull($org);
+
+        $event = new Event();
+        $event->setTitle('Cascade Event')
+            ->setDescription('desc')
+            ->setUpdatedBy('test')
+            ->setEditable(true)
+            ->setOrganization($org);
+
+        $occurrence = new Occurrence();
+        $occurrence->setStart(new \DateTimeImmutable('2026-07-01 10:00:00', new \DateTimeZone('UTC')))
+            ->setEnd(new \DateTimeImmutable('2026-07-01 12:00:00', new \DateTimeZone('UTC')))
+            ->setEvent($event);
+        $event->addOccurrence($occurrence);
+
+        $em->persist($event);
+        $em->persist($occurrence);
+        $em->flush();
+
+        $eventId = $event->getId();
+        $occurrenceId = $occurrence->getId();
+        self::assertNotNull($occurrenceId);
+
+        $em->remove($event);
+        $em->flush();
+        $em->clear();
+
+        self::assertNull($em->getRepository(Event::class)->find($eventId));
+        self::assertNull(
+            $em->getRepository(Occurrence::class)->find($occurrenceId),
+            'Deleting an event must remove its occurrences',
+        );
+    }
+}

--- a/tests/Functional/Auth/LoginGateTest.php
+++ b/tests/Functional/Auth/LoginGateTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Auth;
+
+use App\DataFixtures\OrganizationFixtures;
+use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Tests\Fixtures\TestUserFixtures;
+use App\Tests\Functional\AbstractAdminTestCase;
+use App\Types\UserRoles;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Characterizes the post-login gates enforced by
+ * {@see \App\Security\EventListener\LoginSuccessListener}: unaccepted terms and
+ * unverified email both redirect away from the admin. These fire on a real form
+ * login (not on the programmatic loginUser() used by the CRUD tests), so they
+ * are exercised here by submitting the login form.
+ *
+ * This is a regression net for the EasyAdmin 4 -> 5 upgrade: the admin is only
+ * reachable through these gates.
+ */
+final class LoginGateTest extends AbstractAdminTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadFixtures([
+            OrganizationFixtures::class,
+            TestUserFixtures::class,
+        ]);
+    }
+
+    private function entityManager(): EntityManagerInterface
+    {
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+        self::assertInstanceOf(EntityManagerInterface::class, $em);
+
+        return $em;
+    }
+
+    private function submitLogin(string $email, string $password = TestUserFixtures::PASSWORD): void
+    {
+        $crawler = $this->client->request('GET', '/admin/login');
+        $form = $crawler->filter('form')->form();
+
+        $this->client->submit($form, [
+            '_username' => $email,
+            '_password' => $password,
+        ]);
+    }
+
+    /**
+     * A user who has not accepted the terms is redirected to the accept-terms
+     * page after login (editor role => the email-verified gate is skipped).
+     */
+    public function testUnacceptedTermsRedirectsToAcceptTerms(): void
+    {
+        // Editor fixtures have termsAcceptedAt = null by default.
+        $this->submitLogin(TestUserFixtures::EDITOR_EMAIL);
+
+        $this->assertResponseRedirects();
+        self::assertStringContainsString(
+            '/admin/accept-terms',
+            (string) $this->client->getResponse()->headers->get('Location'),
+        );
+    }
+
+    /**
+     * Accepting the terms persists the timestamp and lets the user into the admin.
+     */
+    public function testAcceptingTermsPersistsTimestampAndUnblocks(): void
+    {
+        $this->submitLogin(TestUserFixtures::EDITOR_EMAIL);
+        $crawler = $this->client->followRedirect(); // accept-terms page
+
+        $form = $crawler->filter('form')->form();
+        $this->client->submit($form, [
+            'accept_terms_form[agreeTerms]' => '1',
+        ]);
+
+        $this->assertResponseRedirects();
+        self::assertStringContainsString('/admin', (string) $this->client->getResponse()->headers->get('Location'));
+        self::assertStringNotContainsString('/accept-terms', (string) $this->client->getResponse()->headers->get('Location'));
+
+        $this->entityManager()->clear();
+        $editor = static::getContainer()->get(UserRepository::class)->findOneBy(['mail' => TestUserFixtures::EDITOR_EMAIL]);
+        self::assertInstanceOf(User::class, $editor);
+        self::assertNotNull($editor->getTermsAcceptedAt(), 'Accepting the terms must persist termsAcceptedAt');
+    }
+
+    /**
+     * A user who has already accepted the terms reaches the admin directly.
+     */
+    public function testUserWithAcceptedTermsIsNotGated(): void
+    {
+        $em = $this->entityManager();
+        $editor = static::getContainer()->get(UserRepository::class)->findOneBy(['mail' => TestUserFixtures::EDITOR_EMAIL]);
+        self::assertInstanceOf(User::class, $editor);
+        $editor->setTermsAcceptedAt(new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
+        $em->flush();
+
+        $this->submitLogin(TestUserFixtures::EDITOR_EMAIL);
+
+        $this->assertResponseRedirects();
+        self::assertStringNotContainsString('/accept-terms', (string) $this->client->getResponse()->headers->get('Location'));
+    }
+
+    /**
+     * A non-privileged user (below ORGANIZATION_EDITOR) with an unverified email
+     * is bounced back to the login page with an error, even after accepting terms.
+     */
+    public function testUnverifiedPlainUserIsBouncedToLogin(): void
+    {
+        $em = $this->entityManager();
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        self::assertInstanceOf(UserPasswordHasherInterface::class, $hasher);
+
+        $user = new User();
+        $user->setName('Plain User')
+            ->setMail('plain-user@test')
+            ->setRoles([UserRoles::ROLE_USER->value])
+            ->setEnabled(true)
+            ->setUpdatedBy('test')
+            ->setTermsAcceptedAt(new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
+        $user->setPassword($hasher->hashPassword($user, TestUserFixtures::PASSWORD));
+        // emailVerifiedAt intentionally left null.
+        $em->persist($user);
+        $em->flush();
+
+        $this->submitLogin('plain-user@test');
+
+        $this->assertResponseRedirects();
+        self::assertStringContainsString('/admin/login', (string) $this->client->getResponse()->headers->get('Location'));
+    }
+}


### PR DESCRIPTION
Adds a regression net for the EasyAdmin-driven admin **before** the 4.x → 5.x upgrade, based on the earlier Playwright gap analysis. **Tests only — no production code changes.** Everything asserts *current* behavior so the upgrade surfaces any drift.

## What's added (20 tests)

- **`CrudWriteRoundTripTest`** — the biggest gap: existing admin tests only assert GET access, nothing submitted a form. Creates and edits entities through the generated EasyAdmin forms (Tag create/edit, Event edit + blame stamp), and pins the occurrence delete-cascade at the ORM level (EA's delete is JS-driven and can't be submitted headlessly).
- **`CrudRenderMatrixTest`** — DETAIL and EDIT render for all nine CRUD controllers as super-admin against dev-fixture data. Previously only INDEX/NEW were covered, so a field-configurator or template regression on detail/edit was invisible.
- **`LoginGateTest`** — the `LoginSuccessListener` gates (accept-terms + email-verified) that fire on real form login and were untested (the existing `LoginTest` passes partly by accident — an editor is redirected to `/admin/accept-terms/`, which still starts with `/admin`).
- **`AdminActionAuthorizationTest`** — Feed mutations are super-admin only (403 for admin, 200 for super-admin), and feed-imported events are read-only through the admin URL (ADR 007 — previously only unit-tested on `EventVoter`).

## Verification

Full suite: 160 tests, 0 failures. PHPStan level 8 + strict clean. php-cs-fixer clean.

## Finding surfaced (no fix here, per scope)

While writing the Event edit test I hit a latent timezone fragility, worth knowing for the upgrade:

- EasyAdmin's `DateTimeField` is configured globally with `model_timezone=UTC` (`DateTimeFieldConfigurator`). Symfony's `DateTimeType` **throws** if the bound model datetime isn't UTC-zoned: *"Using a DateTime instance with a timezone (Europe/Copenhagen) not matching the configured model timezone UTC is not supported."*
- Gedmo `Timestampable` (and other `new \DateTime()` sites) create datetimes in the **PHP default timezone**. The web/admin tier (`phpfpm`) runs `Europe/Copenhagen` in **both dev and prod** — the base image default; the server override only sets `PHP_TIMEZONE=UTC` on the `supervisor` (async worker) service, not on `phpfpm`. So a just-persisted entity holds a Copenhagen-zoned `updated_at` in memory, consistently across environments.
- This is **not reachable** in normal admin flows: entities are re-hydrated from the DB as UTC on read, and EA always issues a redirect after save (`getRedirectResponseAfterSave`), so persist and form-render never share a request. The test hit it only because it persisted and rendered in one process (fixed with `EntityManager::clear()` to mirror real request isolation).
- **Advice:** it is a latent strictness (not a dev-vs-prod split for the admin — both tiers are Copenhagen). During the EA5 upgrade, watch for any change to redirect-after-save or `DateTimeType` timezone handling that could make it reachable; if it ever is, it would fail identically in dev and prod. Setting the base PHP timezone to `UTC` everywhere would remove the mismatch between the stored model (UTC) and the ambient runtime, and is the lowest-risk hardening.

### Note on the actual timezone split
The only tier pinned to `UTC` in production is the `supervisor` service (async Messenger workers + scheduler). The web/admin `phpfpm` tier and deploy CLI use the image default `Europe/Copenhagen` in both dev and prod. So the genuine dev↔prod timezone split lives in the **async pipeline** (UTC in prod workers, Copenhagen in dev where workers run inside `phpfpm`), not in the admin. Stored instants stay correct there (Doctrine coerces to UTC on write; `TimeInterval` uses an explicit separator timezone), so it is currently masked — but it is the place to watch if pipeline code ever depends on the ambient timezone.