### PR TITLE
fix: parse offset-less feed datetimes in the feed's declared timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-93](https://github.com/itk-dev/event-database-imports/pull/93)
+  Fix feed datetime parsing: interpret offset-less feed datetimes in the feed's declared timezone instead of the
+  worker's ambient PHP timezone, so naive-format feeds are no longer imported 1–2 hours off
+
 - [PR-92](https://github.com/itk-dev/event-database-imports/pull/92)
   Add EasyAdmin characterization tests ahead of the 4→5 upgrade: CRUD detail/edit render matrix, create/edit
   form round-trips, the login accept-terms and email-verified gates, and feed/ADR-007 action authorization

--- a/src/Service/Feeds/Mapper/FeedMapper.php
+++ b/src/Service/Feeds/Mapper/FeedMapper.php
@@ -22,6 +22,15 @@ final readonly class FeedMapper implements FeedMapperInterface
 
     public function getFeedItemFromArray(array $data, FeedConfiguration $configuration): FeedItemData
     {
+        // Feed datetimes without an explicit offset are parsed by Valinor with
+        // DateTimeImmutable::createFromFormat(), which falls back to the ambient
+        // PHP timezone. That differs between environments (UTC on the prod
+        // worker, Europe/Copenhagen in dev), so naive feed times were stored
+        // 1-2h off in production. Interpret the mapping in the feed's declared
+        // timezone instead; values that carry their own offset are unaffected.
+        $previousTimezone = date_default_timezone_get();
+        date_default_timezone_set($configuration->timezone);
+
         try {
             return (new MapperBuilder())
                 ->allowSuperfluousKeys()
@@ -39,6 +48,8 @@ final readonly class FeedMapper implements FeedMapperInterface
                 $this->logger->error($message);
             }
             throw $error;
+        } finally {
+            date_default_timezone_set($previousTimezone);
         }
     }
 }

--- a/tests/Functional/Service/Feeds/FeedMapperTimezoneTest.php
+++ b/tests/Functional/Service/Feeds/FeedMapperTimezoneTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Service\Feeds;
+
+use App\Model\Feed\FeedConfiguration;
+use App\Service\Feeds\Mapper\FeedMapperInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * A feed occurrence datetime without an explicit offset must be interpreted in
+ * the feed's declared timezone — not the worker's ambient PHP timezone (UTC in
+ * production, Europe/Copenhagen in dev). All feeds declare Europe/Copenhagen;
+ * the naive-format ones (e.g. Radar, Aros) are currently parsed in the ambient
+ * timezone, so in production they are stored/served 1–2h off.
+ *
+ * Each test forces the ambient timezone to UTC to reproduce the production
+ * worker and make the assertions independent of the environment's own default.
+ */
+final class FeedMapperTimezoneTest extends KernelTestCase
+{
+    private string $originalTimezone;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalTimezone = date_default_timezone_get();
+        // Reproduce the production async worker (supervisor: PHP_TIMEZONE=UTC).
+        date_default_timezone_set('UTC');
+    }
+
+    protected function tearDown(): void
+    {
+        date_default_timezone_set($this->originalTimezone);
+        parent::tearDown();
+    }
+
+    private function mapper(): FeedMapperInterface
+    {
+        $mapper = self::getContainer()->get(FeedMapperInterface::class);
+        self::assertInstanceOf(FeedMapperInterface::class, $mapper);
+
+        return $mapper;
+    }
+
+    private function config(string $dateFormat): FeedConfiguration
+    {
+        return new FeedConfiguration(
+            type: 'json',
+            url: 'https://example.test/feed',
+            base: 'https://example.test/',
+            timezone: 'Europe/Copenhagen',
+            rootPointer: '/-',
+            dateFormat: $dateFormat,
+            mapping: [
+                'id' => 'id',
+                'occurrences.*.start' => 'occurrences.*.start',
+                'occurrences.*.end' => 'occurrences.*.end',
+            ],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function firstStartAsUtc(array $data, string $dateFormat): string
+    {
+        $item = $this->mapper()->getFeedItemFromArray($data, $this->config($dateFormat));
+        $start = $item->occurrences[0]->start;
+        self::assertInstanceOf(\DateTimeImmutable::class, $start);
+
+        return $start->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i');
+    }
+
+    /**
+     * Offset-less datetime (Radar-style `Y-m-d\TH:i`) → interpreted as
+     * Europe/Copenhagen. 20:45 CEST (August) == 18:45 UTC.
+     */
+    public function testNaiveDatetimeIsInterpretedInFeedTimezone(): void
+    {
+        $data = ['id' => 'evt-1', 'occurrences' => [['start' => '2026-08-15T20:45', 'end' => '2026-08-15T21:45']]];
+
+        self::assertSame('2026-08-15 18:45', $this->firstStartAsUtc($data, 'Y-m-d\TH:i'));
+    }
+
+    /**
+     * Offset-less datetime in winter (Aros-style `Y-m-d\TH:i:s`) → Europe/Copenhagen.
+     * 11:00 CET (March) == 10:00 UTC.
+     */
+    public function testNaiveWinterDatetimeIsInterpretedInFeedTimezone(): void
+    {
+        $data = ['id' => 'evt-2', 'occurrences' => [['start' => '2026-03-03T11:00:00', 'end' => '2026-03-03T12:00:00']]];
+
+        self::assertSame('2026-03-03 10:00', $this->firstStartAsUtc($data, 'Y-m-d\TH:i:s'));
+    }
+
+    /**
+     * Offset-bearing datetime (Bora Bora-style `Y-m-d\TH:i:sP`) keeps its own
+     * offset regardless of the feed timezone or the ambient timezone.
+     * 19:30+02:00 == 17:30 UTC.
+     */
+    public function testOffsetBearingDatetimeKeepsItsOffset(): void
+    {
+        $data = ['id' => 'evt-3', 'occurrences' => [['start' => '2026-09-04T19:30:00+02:00', 'end' => '2026-09-04T21:00:00+02:00']]];
+
+        self::assertSame('2026-09-04 17:30', $this->firstStartAsUtc($data, 'Y-m-d\TH:i:sP'));
+    }
+}


### PR DESCRIPTION
Fixes the feed import timezone bug validated against prod data and the live public API: naive-format feeds are imported (and served) 1–2 hours off.

## Root cause

`FeedMapper` maps feed datetimes with Valinor, which uses `DateTimeImmutable::createFromFormat($format, $value)` — no timezone, so offset-less values fall back to the **ambient PHP timezone**. That timezone is `UTC` on the production async worker (`supervisor`) but `Europe/Copenhagen` in dev, so a feed value like `2026-08-15T20:45` (local Aarhus) is stored as `20:45 UTC` in prod instead of `18:45 UTC`, then served as `22:45+02:00`.

All 12 feeds declare `Europe/Copenhagen`; the affected ones are those whose `dateFormat` carries no offset token — **Radar (#8), Aros (#2), Smag på Aarhus (#10)** (all enabled). Offset-bearing feeds (Bora Bora, NEXT, Gruppe 38, Dokk1) were always correct.

## Fix

Interpret the mapping in the feed's declared `timezone` for the duration of the `map()` call, restoring the previous default in a `finally`. Valinor's parse semantics are otherwise unchanged, and values carrying their own offset are unaffected (an explicit offset always wins over the default). This makes the ambient PHP timezone irrelevant to feed parsing — so the earlier idea of removing `PHP_TIMEZONE=UTC` from the supervisor is no longer needed.

## Tests (TDD, red → green)

`FeedMapperTimezoneTest` forces the ambient timezone to `UTC` (reproducing the prod worker) so it's environment-independent, then asserts:
- naive summer `20:45` → `18:45 UTC` (was `20:45 UTC` — red)
- naive winter `11:00` → `10:00 UTC` (was `11:00 UTC` — red)
- offset-bearing `19:30+02:00` → `17:30 UTC` (green before and after — control)

Full suite: 163 tests, 0 failures. PHPStan level 8 + strict clean. php-cs-fixer clean.

## Operational follow-up (not in this PR)

This corrects **new** imports only. Existing occurrences from the three naive feeds are already stored 1–2h off, so after deploy they need a **re-import** and an ES **re-populate** to fix historical data (and the derived daily-occurrences / index the public API reads). Verification evidence (feed ↔ DB ↔ live API) is in the linked investigation.