### PR TITLE
chore: align supervisor timezone on Europe/Copenhagen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-94](https://github.com/itk-dev/event-database-imports/pull/94)
+  Align the async worker (supervisor) on the default Europe/Copenhagen timezone by removing the PHP_TIMEZONE=UTC
+  override, so all runtime tiers share one timezone
+
 - [PR-92](https://github.com/itk-dev/event-database-imports/pull/92)
   Add EasyAdmin characterization tests ahead of the 4→5 upgrade: CRUD detail/edit render matrix, create/edit
   form round-trips, the login accept-terms and email-verified gates, and feed/ADR-007 action authorization

--- a/docker-compose.server.override.yml
+++ b/docker-compose.server.override.yml
@@ -23,7 +23,6 @@ services:
       - APP_SUPERVISOR_USER=deploy
       - PHP_MAX_EXECUTION_TIME=30
       - PHP_MEMORY_LIMIT=256M
-      - PHP_TIMEZONE=UTC
     networks:
       - app
     extra_hosts:


### PR DESCRIPTION
Removes the `PHP_TIMEZONE=UTC` override from the `supervisor` (async worker) service so it falls back to the image default `Europe/Copenhagen`.

## Why

The supervisor was the **only** tier pinned to UTC — the web/CLI (`phpfpm`) tier and dev already run `Europe/Copenhagen` (the base image default). That split was introduced incidentally in PR #47 (a `--force` import PR) and never applied to `phpfpm`. Removing it gives every runtime tier one consistent timezone and eliminates the dev↔prod divergence in the async pipeline.

## Scope / safety

- Config only; one line removed. `docker compose config` validates.
- Feeds that carry an explicit offset are unaffected regardless of tier timezone.
- The offset-less feed-parsing bug itself is fixed independently in #93 (the mapper now interprets naive datetimes in the feed's declared timezone), which makes the ambient tier timezone irrelevant to correctness. This PR is the consistency/hygiene follow-up: one timezone everywhere.

## Interplay with #93

Order-independent. If this merges first, the worker moves to Copenhagen (which alone also corrects naive-feed imports); if #93 merges first, this is pure consistency. Either way, after both, feed correctness no longer depends on the runtime timezone.