### PR TITLE
chore: upgrade EasyAdmin from 4 to 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-95](https://github.com/itk-dev/event-database-imports/pull/95)
+  Upgrade EasyAdmin from 4 to 5: apply the mandatory #[AdminDashboard] attribute, switch menu items from
+  linkToCrud() to linkTo(), and resolve the AdminContext in the login template (EA5 removed the deprecated APIs)
+
 - [PR-94](https://github.com/itk-dev/event-database-imports/pull/94)
   Align the async worker (supervisor) on the default Europe/Copenhagen timezone by removing the PHP_TIMEZONE=UTC
   override, so all runtime tiers share one timezone

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "doctrine/doctrine-migrations-bundle": "^3.2",
         "doctrine/orm": "^2.15",
         "dragonmantank/cron-expression": "^3.3",
-        "easycorp/easyadmin-bundle": "^4.8",
+        "easycorp/easyadmin-bundle": "^5.0",
         "elasticsearch/elasticsearch": "^8.13",
         "guzzlehttp/guzzle": "^7.7",
         "league/uri": "^7.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1bae3dca261fdf9b2dc77d9391c1e382",
+    "content-hash": "ab204d5e02eaab9741c45a4b934332d2",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -1616,73 +1616,75 @@
         },
         {
             "name": "easycorp/easyadmin-bundle",
-            "version": "v4.29.13",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/EasyCorp/EasyAdminBundle.git",
-                "reference": "17bf02b05e704c62c08d9ccee0ede05f57188e49"
+                "reference": "45af742ad9195f06f6c8894aa93530f143130926"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/EasyCorp/EasyAdminBundle/zipball/17bf02b05e704c62c08d9ccee0ede05f57188e49",
-                "reference": "17bf02b05e704c62c08d9ccee0ede05f57188e49",
+                "url": "https://api.github.com/repos/EasyCorp/EasyAdminBundle/zipball/45af742ad9195f06f6c8894aa93530f143130926",
+                "reference": "45af742ad9195f06f6c8894aa93530f143130926",
                 "shasum": ""
             },
             "require": {
-                "doctrine/doctrine-bundle": "^2.5|^3.0",
-                "doctrine/orm": "^2.12|^3.0",
-                "php": ">=8.1",
-                "symfony/asset": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/cache": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/config": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/dependency-injection": "^5.4|^6.0|^7.0|^8.0",
+                "doctrine/dbal": "^3.10|^4.4",
+                "doctrine/doctrine-bundle": "^2.18|^3.2",
+                "doctrine/orm": "^2.20|^3.6",
+                "php": ">=8.2",
+                "symfony/asset": "^6.4|^7.0|^8.0",
+                "symfony/cache": "^6.4.33|^7.0|^8.0",
+                "symfony/config": "^6.4.32|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4.32|^7.0|^8.0",
                 "symfony/deprecation-contracts": "^3.0",
-                "symfony/doctrine-bridge": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/event-dispatcher": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/filesystem": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/form": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/framework-bundle": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/http-foundation": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/http-kernel": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/intl": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/property-access": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/security-bundle": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/string": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/translation": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/twig-bridge": "^5.4.48|^6.4.16|^7.1.9|^8.0",
-                "symfony/twig-bundle": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/uid": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/ux-twig-component": "^2.21",
-                "symfony/validator": "^5.4|^6.0|^7.0|^8.0",
-                "twig/extra-bundle": "^3.17",
-                "twig/html-extra": "^3.17",
-                "twig/twig": "^3.20"
-            },
-            "conflict": {
-                "symfony/error-handler": "<5.4.35"
+                "symfony/doctrine-bridge": "^6.4.32|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4.32|^7.0|^8.0",
+                "symfony/filesystem": "^6.4.30|^7.0|^8.0",
+                "symfony/form": "^6.4.32|^7.0|^8.0",
+                "symfony/framework-bundle": "^6.4.33|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4.33|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4.33|^7.0|^8.0",
+                "symfony/intl": "^6.4.32|^7.0|^8.0",
+                "symfony/property-access": "^6.4.32|^7.0|^8.0",
+                "symfony/security-bundle": "^6.4.32|^7.0|^8.0",
+                "symfony/string": "^6.4.30|^7.0|^8.0",
+                "symfony/translation": "^6.4.32|^7.0|^8.0",
+                "symfony/twig-bridge": "^6.4.32|^7.1.9|^7.2|^8.0",
+                "symfony/twig-bundle": "^6.4.32|^7.0|^8.0",
+                "symfony/uid": "^6.4.32|^7.0|^8.0",
+                "symfony/ux-twig-component": "^2.32|^3.0",
+                "symfony/validator": "^6.4.33|^7.0|^8.0",
+                "twig/extra-bundle": "^3.23",
+                "twig/html-extra": "^3.23",
+                "twig/twig": "^3.23"
             },
             "require-dev": {
+                "dama/doctrine-test-bundle": "^8.2",
                 "doctrine/doctrine-fixtures-bundle": "^3.4|3.5.x-dev|^4.0",
+                "league/flysystem": "^3.10",
+                "moneyphp/money": "^4.8",
                 "phpstan/extension-installer": "^1.4",
                 "phpstan/phpstan": "^2.0",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpstan/phpstan-strict-rules": "^2.0",
                 "phpstan/phpstan-symfony": "^2.0",
                 "psr/log": "^1.0|^2.0|^3.0",
-                "symfony/browser-kit": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/css-selector": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/debug-bundle": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/dom-crawler": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/expression-language": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/phpunit-bridge": "^6.1|^7.0|^8.0",
-                "symfony/process": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/web-link": "^5.4|^6.0|^7.0|^8.0",
-                "vincentlanglet/twig-cs-fixer": "^3.10"
+                "symfony/browser-kit": "^6.4.32|^7.0|^8.0",
+                "symfony/css-selector": "^6.4.24|^7.0|^8.0",
+                "symfony/debug-bundle": "^6.4.27|^7.0|^8.0",
+                "symfony/dom-crawler": "^6.4.32|^7.0|^8.0",
+                "symfony/expression-language": "^6.4.32|^7.0|^8.0",
+                "symfony/phpunit-bridge": "^6.4.26|^7.0|^8.0",
+                "symfony/process": "^6.4.33|^7.0|^8.0",
+                "symfony/web-link": "^6.4.32|^7.0|^8.0",
+                "vincentlanglet/twig-cs-fixer": "^3.10",
+                "zenstruck/foundry": "^2.3"
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -1709,7 +1711,7 @@
             ],
             "support": {
                 "issues": "https://github.com/EasyCorp/EasyAdminBundle/issues",
-                "source": "https://github.com/EasyCorp/EasyAdminBundle/tree/v4.29.13"
+                "source": "https://github.com/EasyCorp/EasyAdminBundle/tree/v5.1.0"
             },
             "funding": [
                 {
@@ -1717,7 +1719,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-20T16:26:42+00:00"
+            "time": "2026-06-20T17:16:01+00:00"
         },
         {
             "name": "egulias/email-validator",

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -2,16 +2,9 @@
 
 namespace App\Controller\Admin;
 
-use App\Entity\Address;
-use App\Entity\Event;
-use App\Entity\Feed;
-use App\Entity\FeedItem;
-use App\Entity\Location;
-use App\Entity\Organization;
-use App\Entity\Tag;
 use App\Entity\User;
-use App\Entity\Vocabulary;
 use App\Types\UserRoles;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Assets;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
@@ -21,10 +14,10 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\UserMenu;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Translation\TranslatableMessage;
 
+#[AdminDashboard(routePath: '/admin', routeName: 'admin')]
 class DashboardController extends AbstractDashboardController
 {
     public const string MODEL_TIMEZONE = 'UTC';
@@ -42,7 +35,6 @@ class DashboardController extends AbstractDashboardController
     ) {
     }
 
-    #[Route('/admin', name: 'admin')]
     public function index(): Response
     {
         $adminUrlGenerator = $this->container->get(AdminUrlGenerator::class);
@@ -71,47 +63,36 @@ class DashboardController extends AbstractDashboardController
         // My Content
         yield MenuItem::section(new TranslatableMessage('admin.label.my_content'))
             ->setPermission(UserRoles::ROLE_ORGANIZATION_EDITOR->value);
-        yield MenuItem::linkToCrud(new TranslatableMessage('admin.link.events'), 'fa fa-calendar', Event::class)
-            ->setController(MyEventCrudController::class)
+        yield MenuItem::linkTo(MyEventCrudController::class, new TranslatableMessage('admin.link.events'), 'fa fa-calendar')
             ->setPermission(UserRoles::ROLE_ORGANIZATION_EDITOR->value);
-        yield MenuItem::linkToCrud(new TranslatableMessage('admin.link.organizations'), 'fa fa-sitemap', Organization::class)
-            ->setController(MyOrganizationCrudController::class)
+        yield MenuItem::linkTo(MyOrganizationCrudController::class, new TranslatableMessage('admin.link.organizations'), 'fa fa-sitemap')
             ->setPermission(UserRoles::ROLE_ORGANIZATION_EDITOR->value);
 
         // All Content
         yield MenuItem::section(new TranslatableMessage('admin.label.all_content'));
-        yield MenuItem::linkToCrud(new TranslatableMessage('admin.link.events'), 'fa fa-calendar', Event::class)
-            ->setController(EventCrudController::class)
+        yield MenuItem::linkTo(EventCrudController::class, new TranslatableMessage('admin.link.events'), 'fa fa-calendar')
             ->setPermission(UserRoles::ROLE_USER->value);
-        yield MenuItem::linkToCrud(new TranslatableMessage('admin.link.organizations'), 'fa fa-sitemap', Organization::class)
-            ->setController(OrganizationCrudController::class)
+        yield MenuItem::linkTo(OrganizationCrudController::class, new TranslatableMessage('admin.link.organizations'), 'fa fa-sitemap')
             ->setPermission(UserRoles::ROLE_USER->value);
-        yield MenuItem::linkToCrud(new TranslatableMessage('admin.link.location'), 'fa fa-location-dot', Location::class)
-            ->setController(LocationCrudController::class)
+        yield MenuItem::linkTo(LocationCrudController::class, new TranslatableMessage('admin.link.location'), 'fa fa-location-dot')
             ->setPermission(UserRoles::ROLE_USER->value);
-        yield MenuItem::linkToCrud(new TranslatableMessage('admin.link.address'), 'fa fa-address-book', Address::class)
-            ->setController(AddressCrudController::class)
+        yield MenuItem::linkTo(AddressCrudController::class, new TranslatableMessage('admin.link.address'), 'fa fa-address-book')
             ->setPermission(UserRoles::ROLE_USER->value);
-        yield MenuItem::linkToCrud(new TranslatableMessage('admin.link.tags'), 'fa fa-tags', Tag::class)
-            ->setController(TagCrudController::class)
+        yield MenuItem::linkTo(TagCrudController::class, new TranslatableMessage('admin.link.tags'), 'fa fa-tags')
             ->setPermission(UserRoles::ROLE_USER->value);
-        yield MenuItem::linkToCrud(new TranslatableMessage('admin.link.vocabularies'), 'fa fa-book', Vocabulary::class)
-            ->setController(VocabularyCrudController::class)
+        yield MenuItem::linkTo(VocabularyCrudController::class, new TranslatableMessage('admin.link.vocabularies'), 'fa fa-book')
             ->setPermission(UserRoles::ROLE_ADMIN->value);
 
         yield MenuItem::section(new TranslatableMessage('admin.label.feeds'))
             ->setPermission(UserRoles::ROLE_ADMIN->value);
-        yield MenuItem::linkToCrud(new TranslatableMessage('admin.link.feeds'), 'fa fa-rss', Feed::class)
-            ->setController(FeedCrudController::class)
+        yield MenuItem::linkTo(FeedCrudController::class, new TranslatableMessage('admin.link.feeds'), 'fa fa-rss')
             ->setPermission(UserRoles::ROLE_ADMIN->value);
-        yield MenuItem::linkToCrud(new TranslatableMessage('admin.link.feedItems'), 'fa fa-list-alt', FeedItem::class)
-            ->setController(FeedItemCrudController::class)
+        yield MenuItem::linkTo(FeedItemCrudController::class, new TranslatableMessage('admin.link.feedItems'), 'fa fa-list-alt')
             ->setPermission(UserRoles::ROLE_ADMIN->value);
 
         yield MenuItem::section(new TranslatableMessage('admin.label.users'))
             ->setPermission(UserRoles::ROLE_ADMIN->value);
-        yield MenuItem::linkToCrud(new TranslatableMessage('admin.link.users'), 'fa fa-user', User::class)
-            ->setController(UserCrudController::class)
+        yield MenuItem::linkTo(UserCrudController::class, new TranslatableMessage('admin.link.users'), 'fa fa-user')
             ->setPermission(UserRoles::ROLE_ADMIN->value);
     }
 

--- a/templates/app/landing_page/index.html.twig
+++ b/templates/app/landing_page/index.html.twig
@@ -1,5 +1,9 @@
 {% extends 'app/base.html.twig' %}
 
+{# Resolve the current AdminContext (null outside an admin request, e.g. login),
+   mirroring EasyAdmin's own login template. The global "ea" is the provider. #}
+{% set ea = ea() %}
+
 {% set _username_label = username_label is defined ? username_label|trans : 'login_page.username'|trans({}, 'EasyAdminBundle') %}
 {% set _password_label = password_label is defined ? password_label|trans : 'login_page.password'|trans({}, 'EasyAdminBundle') %}
 {% set _forgot_password_label = forgot_password_label is defined ? forgot_password_label|trans : 'login_page.forgot_password'|trans({}, 'EasyAdminBundle') %}
@@ -34,7 +38,7 @@
             <input type="hidden" name="_csrf_token" value="{{ csrf_token(csrf_token_intention) }}">
         {% endif %}
 
-        <input type="hidden" name="{{ target_path_parameter|default('_target_path') }}" value="{{ target_path|default(ea.hasContext ? path(ea.dashboardRouteName) : '/') }}" />
+        <input type="hidden" name="{{ target_path_parameter|default('_target_path') }}" value="{{ target_path|default(null != ea ? path(ea.dashboardRouteName) : '/') }}" />
 
         <div class="form-group">
             <label class="form-control-label required" for="username">{{ _username_label }}</label>


### PR DESCRIPTION
Upgrades EasyAdmin 4.29.13 → 5.1.0. EA 5.0 is "the same features as the latest 4.x with all deprecated features removed" (the Symfony X.4→(X+1).0 model), so the work was resolving the deprecations we still used — verified against the characterization suite added in #92.

## Changes

- **Bump** `easycorp/easyadmin-bundle` `^4.8` → `^5.0` (installs v5.1.0). No other dependency changes (Symfony 7.4 already compatible).
- **`DashboardController`**: apply the now-mandatory `#[AdminDashboard(routePath: '/admin', routeName: 'admin')]` class attribute (replacing Symfony's `#[Route]` on `index()`), and migrate the 11 menu items from the removed `MenuItem::linkToCrud(label, icon, entity)->setController(ctrl)` to `MenuItem::linkTo(ctrl, label, icon)`.
- **Login template** (`app/landing_page/index.html.twig`): EA5's `AdminContextProvider` no longer exposes `hasContext()`/`dashboardRouteName()`. Resolve the `AdminContext` with `{% set ea = ea() %}` (null outside an admin request), mirroring EA's own login template, so the guarded `target_path` expression works.

## Verification

- Characterization suite (**#92**) is the acceptance gate: full suite **163 tests green, 0 failures**; **0 EasyAdmin deprecations** remaining.
- `lint:container`, PHPStan level 8 + strict, php-cs-fixer, twig-cs-fixer all clean; `composer validate`/`normalize` clean.
- **Live Playwright smoke on EA5**: login → accept-terms gate → event index → full Event edit form (rich-text, image, occurrences collection, tags, organizer) all render with **0 console errors**.
- **Custom theming intact**: `configureAssets()` (`addCssFile`/`addJsFile`) still works — `/admin/styles/admin.css`, custom JS, logo/favicon all served 200, and the theming selectors (`.main-header #header-logo svg`, `:root`) still match EA5's DOM and apply.

## Notes for reviewers

During the upgrade the test kernel served stale compiled Twig from 4.29 (surfaced as a phantom `usePrettyUrls` error); a full `var/cache` clear is needed after the bump — deploys run `cache:clear`, so no action required, but worth knowing if running locally.