### PR TITLE
test: Doctrine 3 pre-work — coverage + Criteria deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-96](https://github.com/itk-dev/event-database-imports/pull/96)
+  Doctrine 3 pre-work: cover the UTC immutable datetime type and the populate repository, and replace the
+  deprecated Criteria::ASC constant with the Order enum
+
 - [PR-95](https://github.com/itk-dev/event-database-imports/pull/95)
   Upgrade EasyAdmin from 4 to 5: apply the mandatory #[AdminDashboard] attribute, switch menu items from
   linkToCrud() to linkTo(), and resolve the AdminContext in the login template (EA5 removed the deprecated APIs)

--- a/src/Repository/AbstractPopulateRepository.php
+++ b/src/Repository/AbstractPopulateRepository.php
@@ -4,7 +4,7 @@ namespace App\Repository;
 
 use App\Model\Indexing\IndexNames;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Order;
 use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 
 /**
@@ -18,7 +18,7 @@ abstract class AbstractPopulateRepository extends ServiceEntityRepository implem
     #[\Override]
     public function findToPopulate(array $criteria, int $limit, int $offset): array
     {
-        return $this->findBy($criteria, ['id' => Criteria::ASC], $limit, $offset);
+        return $this->findBy($criteria, ['id' => Order::Ascending->value], $limit, $offset);
     }
 
     #[\Override]

--- a/tests/Functional/Repository/PopulateRepositoryTest.php
+++ b/tests/Functional/Repository/PopulateRepositoryTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Repository;
+
+use App\DataFixtures\OrganizationFixtures;
+use App\Entity\Event;
+use App\Repository\EventRepository;
+use App\Tests\Fixtures\TestEventFixtures;
+use App\Tests\Fixtures\TestUserFixtures;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Characterizes AbstractPopulateRepository (the ES read-model population query),
+ * which had no direct coverage. Exercised through a concrete repository
+ * (EventRepository). Guards the id-ascending ordering and limit/offset paging
+ * that the indexing populate step relies on — including across the upcoming
+ * Criteria::ASC -> Order enum change and the Doctrine 3 upgrade.
+ */
+final class PopulateRepositoryTest extends KernelTestCase
+{
+    private function repository(): EventRepository
+    {
+        $repository = self::getContainer()->get(EventRepository::class);
+        self::assertInstanceOf(EventRepository::class, $repository);
+
+        return $repository;
+    }
+
+    private function loadEvents(): void
+    {
+        $tool = self::getContainer()->get(\Liip\TestFixturesBundle\Services\DatabaseToolCollection::class)->get();
+        $tool->loadFixtures([
+            OrganizationFixtures::class,
+            TestUserFixtures::class,
+            TestEventFixtures::class,
+        ]);
+    }
+
+    public function testCountToPopulateReturnsTotal(): void
+    {
+        $this->loadEvents();
+
+        // TestEventFixtures creates four events.
+        self::assertSame(4, $this->repository()->countToPopulate([]));
+    }
+
+    public function testFindToPopulateReturnsIdAscending(): void
+    {
+        $this->loadEvents();
+
+        $events = $this->repository()->findToPopulate([], 100, 0);
+
+        $ids = array_map(static fn (Event $e): int => (int) $e->getId(), $events);
+        $sorted = $ids;
+        sort($sorted);
+        self::assertSame($sorted, $ids, 'findToPopulate must return events ordered by id ascending');
+    }
+
+    public function testFindToPopulateRespectsLimitAndOffset(): void
+    {
+        $this->loadEvents();
+
+        $all = $this->repository()->findToPopulate([], 100, 0);
+        self::assertGreaterThanOrEqual(4, count($all));
+
+        $firstTwo = $this->repository()->findToPopulate([], 2, 0);
+        $nextTwo = $this->repository()->findToPopulate([], 2, 2);
+
+        self::assertCount(2, $firstTwo);
+        self::assertCount(2, $nextTwo);
+        // Paging is stable and non-overlapping.
+        self::assertSame($all[0]->getId(), $firstTwo[0]->getId());
+        self::assertSame($all[2]->getId(), $nextTwo[0]->getId());
+    }
+}

--- a/tests/Unit/Doctrine/UTCDateTimeImmutableTypeTest.php
+++ b/tests/Unit/Doctrine/UTCDateTimeImmutableTypeTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Doctrine;
+
+use App\Doctrine\Extensions\DBAL\Types\UTCDateTimeImmutableType;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Characterizes the UTC immutable datetime type on both the write (store as
+ * UTC) and read (hydrate as UTC) paths. These conversions are the parts most
+ * affected by the Doctrine DBAL 4 upgrade, so this pins current behavior first.
+ */
+final class UTCDateTimeImmutableTypeTest extends TestCase
+{
+    private UTCDateTimeImmutableType $type;
+
+    protected function setUp(): void
+    {
+        $this->type = new UTCDateTimeImmutableType();
+    }
+
+    private function platform(): AbstractPlatform
+    {
+        $platform = $this->createStub(AbstractPlatform::class);
+        $platform->method('getDateTimeFormatString')->willReturn('Y-m-d H:i:s');
+
+        return $platform;
+    }
+
+    /**
+     * A non-UTC value is stored as its UTC equivalent.
+     */
+    public function testConvertsNonUtcValueToUtcForStorage(): void
+    {
+        $value = new \DateTimeImmutable('2026-07-01 14:00:00', new \DateTimeZone('Europe/Copenhagen'));
+
+        $db = $this->type->convertToDatabaseValue($value, $this->platform());
+
+        self::assertSame('2026-07-01 12:00:00', $db);
+    }
+
+    /**
+     * Immutable values are never mutated by the conversion — the caller keeps
+     * its original object and timezone.
+     */
+    public function testDoesNotMutateTheGivenObject(): void
+    {
+        $value = new \DateTimeImmutable('2026-07-01 14:00:00', new \DateTimeZone('Europe/Copenhagen'));
+
+        $this->type->convertToDatabaseValue($value, $this->platform());
+
+        self::assertSame('Europe/Copenhagen', $value->getTimezone()->getName());
+        self::assertSame('2026-07-01 14:00:00', $value->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * An already-UTC value round-trips unchanged.
+     */
+    public function testUtcValueIsStoredUnchanged(): void
+    {
+        $value = new \DateTimeImmutable('2026-07-01 12:00:00', new \DateTimeZone('UTC'));
+
+        self::assertSame('2026-07-01 12:00:00', $this->type->convertToDatabaseValue($value, $this->platform()));
+    }
+
+    /**
+     * Null passes through on both paths.
+     */
+    public function testNullIsPreserved(): void
+    {
+        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform()));
+        self::assertNull($this->type->convertToPHPValue(null, $this->platform()));
+    }
+
+    /**
+     * A stored string is hydrated as a UTC-zoned DateTimeImmutable.
+     */
+    public function testConvertToPhpValueHydratesAsUtc(): void
+    {
+        $value = $this->type->convertToPHPValue('2026-07-01 12:00:00', $this->platform());
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $value);
+        self::assertSame('UTC', $value->getTimezone()->getName());
+        self::assertSame('2026-07-01 12:00:00', $value->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * An existing DateTimeImmutable passes through unchanged on read.
+     */
+    public function testConvertToPhpValuePassesThroughExistingObject(): void
+    {
+        $existing = new \DateTimeImmutable('2026-07-01 12:00:00', new \DateTimeZone('UTC'));
+
+        self::assertSame($existing, $this->type->convertToPHPValue($existing, $this->platform()));
+    }
+}


### PR DESCRIPTION
First slice of the Doctrine ORM 2 → 3 (and DBAL 3 → 4) pre-work: close the Doctrine test-coverage gaps that will be the regression net for the upgrade, and clear a related deprecation. No dependency bumps yet.

## Changes

- **`UTCDateTimeImmutableTypeTest`** — the immutable UTC type had no unit test (only the mutable one), yet it's the one hydrated on every read. Covers both conversion paths: store-as-UTC (incl. non-mutation of immutables) and hydrate-as-UTC. These are exactly the paths DBAL 4 reworks.
- **`PopulateRepositoryTest`** — `AbstractPopulateRepository` (the ES read-model population query used by 7 repositories) had no direct coverage. Pins id-ascending ordering + limit/offset paging via `EventRepository`.
- **`Criteria::ASC` → `Order::Ascending->value`** in `AbstractPopulateRepository` — the `Criteria::ASC` constant is deprecated (removed in doctrine/collections 3.0). Behaviour-preserving (both resolve to `'ASC'`), and now guarded by the repository test.

## Verification

Full suite **172 tests, 0 failures** (+9). PHPStan level 8 + strict clean; php-cs-fixer clean.

## Context

Part of the scoped Doctrine 3 upgrade. Remaining pre-work: add Rector as dev tooling (separate PR). The upgrade itself is gated on a dependency bump (`carbon-doctrine-types` ^3 for DBAL 4, Gedmo/DAMA ORM3/DBAL4 support) — tracked separately.