### PR TITLE
chore: add Rector as dev tooling ahead of the Doctrine 3 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-97](https://github.com/itk-dev/event-database-imports/pull/97)
+  Add Rector as dev tooling (task code-analysis:rector) with the Doctrine code-quality set, ahead of the
+  Doctrine 3 upgrade; apply its attribute-key-to-constant suggestions on the Feed and User entities
+
 - [PR-95](https://github.com/itk-dev/event-database-imports/pull/95)
   Upgrade EasyAdmin from 4 to 5: apply the mandatory #[AdminDashboard] attribute, switch menu items from
   linkToCrud() to linkTo(), and resolve the AdminContext in the login template (EA5 removed the deprecated APIs)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -150,6 +150,7 @@ tasks:
     desc: "Run code analysis"
     cmds:
       - task: code-analysis:phpstan
+      - task: code-analysis:rector
     silent: true
 
   code-analysis:phpstan:
@@ -158,6 +159,22 @@ tasks:
       - task: compose
         vars:
           COMPOSE_ARGS: exec phpfpm vendor/bin/phpstan
+    silent: true
+
+  code-analysis:rector:
+    desc: "Check for Rector suggestions (dry-run; no changes applied)"
+    cmds:
+      - task: compose
+        vars:
+          COMPOSE_ARGS: exec phpfpm vendor/bin/rector process --dry-run
+    silent: true
+
+  code-analysis:rector:apply:
+    desc: "Apply Rector changes"
+    cmds:
+      - task: compose
+        vars:
+          COMPOSE_ARGS: exec phpfpm vendor/bin/rector process
     silent: true
 
   test:setup:

--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,7 @@
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/phpstan-symfony": "^2.0",
         "phpunit/phpunit": "^13",
+        "rector/rector": "^2.5",
         "symfony/ai-mate": "^0.10.0",
         "symfony/ai-monolog-mate-extension": "^0.10.0",
         "symfony/ai-symfony-mate-extension": "^0.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab204d5e02eaab9741c45a4b934332d2",
+    "content-hash": "7fb527ea04e83e20b98606b18f474ae3",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -14229,6 +14229,66 @@
                 }
             ],
             "time": "2024-06-11T12:45:25+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "2.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "adaa18d7cd6b3c960967cfbc98c03efb3116ac0e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/adaa18d7cd6b3c960967cfbc98c03efb3116ac0e",
+                "reference": "adaa18d7cd6b3c960967cfbc98c03efb3116ac0e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.2.2"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/2.5.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-06T12:41:46+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Doctrine\Set\DoctrineSetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__.'/src',
+    ])
+    ->withCache(__DIR__.'/var/cache/rector')
+    // Import management is left to php-cs-fixer (PostToolUse hook / coding
+    // standards), so Rector does not touch `use` statements.
+    // Safe on the current stack. The Doctrine ORM 3 / DBAL 4 upgrade sets are
+    // intentionally NOT enabled here — enable them in the upgrade PR, once the
+    // dependencies are bumped, so Rector rewrites for the versions actually
+    // installed:
+    //
+    //     DoctrineSetList::DOCTRINE_DBAL_40
+    //     DoctrineSetList::DOCTRINE_ORM_300
+    //     DoctrineSetList::DOCTRINE_COLLECTION_22
+    ->withSets([
+        DoctrineSetList::DOCTRINE_CODE_QUALITY,
+    ]);

--- a/src/Entity/Feed.php
+++ b/src/Entity/Feed.php
@@ -30,7 +30,7 @@ class Feed
     #[ORM\Column(length: 255)]
     private ?string $name = null;
 
-    #[ORM\Column(type: 'json')]
+    #[ORM\Column(type: Types::JSON)]
     private array $configuration = [];
 
     #[ORM\Column(nullable: true)]

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -45,10 +45,10 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     )]
     private ?string $mail = null;
 
-    #[ORM\Column(type: 'json')]
+    #[ORM\Column(type: Types::JSON)]
     private array $roles = [];
 
-    #[ORM\Column(type: 'boolean')]
+    #[ORM\Column(type: Types::BOOLEAN)]
     private bool $enabled = true;
 
     #[ORM\Column(length: 255)]


### PR DESCRIPTION
Second slice of the Doctrine 3 pre-work: add Rector so the upgrade PR can automate the mechanical churn (deprecated-API rewrites, DBAL/ORM signature changes).

## Changes

- Add `rector/rector` (dev) and a scoped `rector.php`: paths `src/`, `DOCTRINE_CODE_QUALITY` set, cache in `var/`. Import management is deliberately left to php-cs-fixer to avoid the two tools fighting over `use` statements.
- Add task wrappers: `task code-analysis:rector` (dry-run, wired into `task code-analysis`) and `task code-analysis:rector:apply`.
- **The ORM 3 / DBAL 4 upgrade sets are documented but gated** (`DOCTRINE_ORM_300`, `DOCTRINE_DBAL_40`, `DOCTRINE_COLLECTION_22`) — enabled in the upgrade PR once deps are bumped, so Rector rewrites for the versions actually installed. Enabling them now (on ORM 2.20 / DBAL 3) would rewrite against APIs we don't have.
- Applied the one current suggestion (`AttributeKeyToClassConstFetchRector`): `Feed`/`User` entities now use `Types::JSON` / `Types::BOOLEAN` constants instead of string literals. Semantically identical.

## Verification

`task code-analysis:rector` dry-run is clean; full suite **163 tests green**; PHPStan level 8 + strict, php-cs-fixer, prettier all clean.

## Rector evaluation (why it earns its place)

- Automates the boring ~60% of the upgrade (Criteria/Order, DBAL Result/fetch changes, ORM signature/return-type rewrites) via the gated Doctrine sets.
- Won't touch the two risky custom DBAL type classes or resolve the dependency conflicts (Carbon/Gedmo) — those stay manual.
- Reusable for future PHP/Symfony/Doctrine majors, and CI can enforce `--dry-run`.

Stacks with #96 (coverage + Criteria deprecation). Remaining before the upgrade itself: the dependency bump (`carbon-doctrine-types` ^3, Gedmo/DAMA ORM3/DBAL4 support).