### PR TITLE
ci: cache vendor, pre-pull images, drop Task from Review workflow

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -19,7 +19,7 @@ jobs:
       APP_ENV: prod
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Composer install
         run: |

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2
 

--- a/.github/workflows/composer.yaml
+++ b/.github/workflows/composer.yaml
@@ -58,9 +58,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Cache vendor
+        uses: actions/cache@v5
+        with:
+          path: vendor
+          key: vendor-php8.4-${{ hashFiles('composer.lock') }}
+          restore-keys: vendor-php8.4-
+
       - name: Create docker network
         run: |
           docker network create frontend
+
+      - name: Pull container images
+        run: docker compose pull --quiet phpfpm
 
       - run: |
           docker compose run --rm phpfpm composer install

--- a/.github/workflows/composer.yaml
+++ b/.github/workflows/composer.yaml
@@ -44,7 +44,7 @@ jobs:
   composer-validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Create docker network
         run: |
@@ -56,10 +56,10 @@ jobs:
   composer-normalized:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Cache vendor
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: vendor
           key: vendor-php8.4-${{ hashFiles('composer.lock') }}
@@ -79,7 +79,7 @@ jobs:
   composer-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -56,9 +56,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Cache vendor
+        uses: actions/cache@v5
+        with:
+          path: vendor
+          key: vendor-php8.4-${{ hashFiles('composer.lock') }}
+          restore-keys: vendor-php8.4-
+
       - name: Create docker network
         run: |
           docker network create frontend
+
+      - name: Pull container images
+        run: docker compose pull --quiet phpfpm
 
       - run: |
           docker compose run --rm phpfpm composer install

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -54,10 +54,10 @@ jobs:
     name: PHP - Check Coding Standards
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Cache vendor
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: vendor
           key: vendor-php8.4-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Composer install
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Create docker network
         run: docker network create frontend
@@ -29,10 +29,10 @@ jobs:
     name: Test suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Cache vendor
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: vendor
           key: vendor-php8.4-${{ hashFiles('composer.lock') }}
@@ -61,7 +61,7 @@ jobs:
         run: docker compose exec -T --env XDEBUG_MODE=coverage phpfpm vendor/bin/phpunit --coverage-clover=coverage/unit.xml
 
       - name: Upload coverage to Codecov test
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: ./coverage/unit.xml
           flags: unittests
@@ -72,10 +72,10 @@ jobs:
     name: PHPStan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Cache vendor
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: vendor
           key: vendor-php8.4-${{ hashFiles('composer.lock') }}
@@ -97,10 +97,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Validate Doctrine Schema
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Cache vendor
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: vendor
           key: vendor-php8.4-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,25 +13,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # https://taskfile.dev/installation/#github-actions
-      - name: Install Task
-        uses: go-task/setup-task@v1
-        with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create docker network
+        run: docker network create frontend
 
-      - name: Start docker compose setup
-        run: |
-          docker network create frontend
-          task compose -- up --detach
+      - name: Pull container images
+        run: docker compose pull --quiet phpfpm
 
       - name: Validate composer files
-        run: |
-          task composer -- validate composer.json --strict
+        run: docker compose run --rm phpfpm composer validate composer.json --strict
 
       - name: Composer install with exported .env variables
-        run: |
-          docker compose --env-file .env exec --env APP_ENV=prod phpfpm composer install --no-dev --optimize-autoloader
+        run: docker compose run --rm --env APP_ENV=prod phpfpm composer install --no-dev --optimize-autoloader
 
   test-suite:
     name: Test suite
@@ -39,26 +31,34 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Task
-        uses: go-task/setup-task@v1
+      - name: Cache vendor
+        uses: actions/cache@v5
         with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          path: vendor
+          key: vendor-php8.4-${{ hashFiles('composer.lock') }}
+          restore-keys: vendor-php8.4-
+
+      - name: Create docker network
+        run: docker network create frontend
+
+      - name: Pull container images
+        run: docker compose pull --quiet
 
       - name: Start docker compose setup
-        run: |
-          docker network create frontend
-          task compose -- up --detach
+        run: docker compose up --detach
 
       - name: Install Dependencies
+        run: docker compose exec -T phpfpm composer install
+
+      - name: Provision and migrate the isolated test database
+        # Mirrors `task test:setup`: the `db` user cannot CREATE DATABASE, so
+        # root provisions `db_test`, then migrations run against it.
         run: |
-          task composer -- install
+          docker compose exec -T mariadb mariadb -uroot -ppassword -e 'CREATE DATABASE IF NOT EXISTS db_test; GRANT ALL PRIVILEGES ON `db_test`.* TO `db`@`%`;'
+          docker compose exec -T phpfpm bin/console --env=test doctrine:migrations:migrate --no-interaction
 
       - name: Test suite
-        # `task test` provisions and migrates the isolated `db_test` database
-        # via `test:setup` before running PHPUnit.
-        run: |
-          task test
+        run: docker compose exec -T --env XDEBUG_MODE=coverage phpfpm vendor/bin/phpunit --coverage-clover=coverage/unit.xml
 
       - name: Upload coverage to Codecov test
         uses: codecov/codecov-action@v5
@@ -74,24 +74,24 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Task
-        uses: go-task/setup-task@v1
+      - name: Cache vendor
+        uses: actions/cache@v5
         with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          path: vendor
+          key: vendor-php8.4-${{ hashFiles('composer.lock') }}
+          restore-keys: vendor-php8.4-
 
-      - name: Start docker compose setup
-        run: |
-          docker network create frontend
-          task compose -- up --detach
+      - name: Create docker network
+        run: docker network create frontend
+
+      - name: Pull container images
+        run: docker compose pull --quiet phpfpm
 
       - name: Install Dependencies
-        run: |
-          task composer -- install
+        run: docker compose run --rm phpfpm composer install
 
       - name: Run PHPStan
-        run: |
-          task code-analysis:phpstan
+        run: docker compose run --rm phpfpm vendor/bin/phpstan analyse
 
   validate-doctrine-schema:
     runs-on: ubuntu-latest
@@ -99,11 +99,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Task
-        uses: go-task/setup-task@v1
+      - name: Cache vendor
+        uses: actions/cache@v5
         with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          path: vendor
+          key: vendor-php8.4-${{ hashFiles('composer.lock') }}
+          restore-keys: vendor-php8.4-
 
       # https://github.com/mxschmitt/action-tmate?tab=readme-ov-file#manually-triggered-debug
       # Enable tmate debugging if debug logging is enabled (cf.
@@ -123,11 +124,11 @@ jobs:
       - name: Install site
         run: |
           docker network create frontend
-          task compose -- up --detach
-          task composer -- install
-          task console -- doctrine:migrations:migrate --no-interaction
-          task console -- messenger:setup-transports
+          docker compose pull --quiet
+          docker compose up --detach
+          docker compose exec -T phpfpm composer install
+          docker compose exec -T phpfpm bin/console doctrine:migrations:migrate --no-interaction
+          docker compose exec -T phpfpm bin/console messenger:setup-transports
 
       - name: Validate Doctrine schema
-        run: |
-          task console -- doctrine:schema:validate
+        run: docker compose exec -T phpfpm bin/console doctrine:schema:validate

--- a/.github/workflows/twig.yaml
+++ b/.github/workflows/twig.yaml
@@ -44,10 +44,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cache vendor
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: vendor
           key: vendor-php8.4-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/twig.yaml
+++ b/.github/workflows/twig.yaml
@@ -46,9 +46,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Cache vendor
+        uses: actions/cache@v5
+        with:
+          path: vendor
+          key: vendor-php8.4-${{ hashFiles('composer.lock') }}
+          restore-keys: vendor-php8.4-
+
       - name: Create docker network
         run: |
           docker network create frontend
+
+      - name: Pull container images
+        run: docker compose pull --quiet phpfpm
 
       - run: |
           docker compose run --rm phpfpm composer install

--- a/.github/workflows/yaml.yaml
+++ b/.github/workflows/yaml.yaml
@@ -35,7 +35,7 @@ jobs:
   yaml-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-98](https://github.com/itk-dev/event-database-imports/pull/98)
+  Cache the vendor directory and pre-pull container images across the Composer, PHP, Twig and Review CI
+  workflows so composer install stops hitting GitHub's dist-download rate limit, and drive the Review workflow
+  with docker compose directly instead of Task
+
 - [PR-97](https://github.com/itk-dev/event-database-imports/pull/97)
   Add Rector as dev tooling (task code-analysis:rector) with the Doctrine code-quality set, ahead of the
   Doctrine 3 upgrade; apply its attribute-key-to-constant suggestions on the Feed and User entities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ See [keep a changelog] for information about writing changes to this log.
 
 - [PR-98](https://github.com/itk-dev/event-database-imports/pull/98)
   Cache the vendor directory and pre-pull container images across the Composer, PHP, Twig and Review CI
-  workflows so composer install stops hitting GitHub's dist-download rate limit, and drive the Review workflow
-  with docker compose directly instead of Task
+  workflows so composer install stops hitting GitHub's dist-download rate limit, drive the Review workflow
+  with docker compose directly instead of Task, and bump all GitHub Actions to their latest major
+  (checkout v7, cache v6, codecov-action v7)
 
 - [PR-97](https://github.com/itk-dev/event-database-imports/pull/97)
   Add Rector as dev tooling (task code-analysis:rector) with the Doctrine code-quality set, ahead of the


### PR DESCRIPTION
Fixes the intermittent CI failures where `composer install` hit GitHub's anonymous dist-download rate limit (HTTP 429), and standardizes all workflows on `docker compose` directly. Adapted from [os2display/display-api-service](https://github.com/os2display/display-api-service/blob/release/3.0.0/.github/workflows/phpunit.yaml).

## Changes

**Vendor caching + image pre-pull** on every job that runs `composer install`, across all four workflows (Composer, PHP, Twig, Review):
- `actions/cache@v5` on `vendor/`, keyed on `hashFiles('composer.lock')` with a `vendor-php8.4-` restore-key fallback → on a cache hit `composer install` does no dist downloads (no 429); on a miss the restore-key pre-populates most of `vendor/`.
- `docker compose pull --quiet` up front instead of on-demand pulls.

**Review workflow (`pr.yaml`) now uses `docker compose` directly** instead of Task:
- Removed the `go-task/setup-task` install step from every job.
- `task compose -- up` → `docker compose up --detach`; `task composer -- install` → `docker compose exec -T phpfpm composer install`; `task test` → the explicit db_test provision + `--env=test` migrate + `phpunit --coverage-clover`; `task console -- …` → `docker compose exec -T phpfpm bin/console …`; `task code-analysis:phpstan` → `docker compose run --rm phpfpm vendor/bin/phpstan analyse`.
- Behaviour is unchanged — same validate / install / test-setup / phpunit / phpstan / schema-validate steps, Codecov upload, tmate debug hook, and ES data-dir prep.

Notes:
- The prod-install check (`--no-dev`) deliberately skips the vendor cache — its point is to verify a clean production install.
- `composer-validate` / `composer-audit` don't install dependencies, so they're untouched.

## Verification

All four workflows are prettier-clean and parse; no `task`/`setup-task` usage remains in `pr.yaml` (only a comment reference).