### PR TITLE
chore: upgrade cuyz/valinor to 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-101](https://github.com/itk-dev/event-database-imports/pull/101)
+  Upgrade cuyz/valinor 1→2: replace the removed `enableFlexibleCasting()` with its granular successors
+  (`allowScalarValueCasting`, `allowNonSequentialList`, `allowUndefinedValues`) and swap the removed
+  `Messages::flattenFromNode($error->node())` error handling for `MappingError::messages()` in the feed
+  item and configuration mappers. Add regression tests covering both mappers' scalar-casting and
+  MappingError branches ahead of the bump (FeedConfigurationMapper was previously untested)
+
 - [PR-100](https://github.com/itk-dev/event-database-imports/pull/100)
   Follow-up to the Doctrine 3 upgrade: bring the remaining Doctrine bundles to their latest majors
   (doctrine-bundle 2→3, doctrine-migrations-bundle 3→4, doctrine-fixtures-bundle 3→4), drop the ORM/DBAL

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "ext-iconv": "*",
         "ext-pdo": "*",
         "cerbero/json-parser": "^1.0",
-        "cuyz/valinor": "^1.4",
+        "cuyz/valinor": "^2.0",
         "doctrine/doctrine-bundle": "^3.0",
         "doctrine/doctrine-migrations-bundle": "^4.0",
         "doctrine/orm": "^3.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea661aaa2bfa56de7fe3c8802d4befaa",
+    "content-hash": "623a7eb1ce1913650ce74773694729e7",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -152,37 +152,36 @@
         },
         {
             "name": "cuyz/valinor",
-            "version": "1.17.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CuyZ/Valinor.git",
-                "reference": "9eb2802797e36f3af1fd6e13ff23e4e3d0058022"
+                "reference": "afbe7352692d5925a76edd53d5998161334056d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CuyZ/Valinor/zipball/9eb2802797e36f3af1fd6e13ff23e4e3d0058022",
-                "reference": "9eb2802797e36f3af1fd6e13ff23e4e3d0058022",
+                "url": "https://api.github.com/repos/CuyZ/Valinor/zipball/afbe7352692d5925a76edd53d5998161334056d4",
+                "reference": "afbe7352692d5925a76edd53d5998161334056d4",
                 "shasum": ""
             },
             "require": {
-                "composer-runtime-api": "^2.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-                "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "conflict": {
                 "phpstan/phpstan": "<1.0 || >= 3.0",
                 "vimeo/psalm": "<5.0 || >=7.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.4",
-                "infection/infection": "^0.29",
+                "friendsofphp/php-cs-fixer": "^3.91",
+                "infection/infection": "^0.32",
                 "marcocesarato/php-conventional-changelog": "^1.12",
                 "mikey179/vfsstream": "^1.6.10",
                 "phpbench/phpbench": "^1.3",
                 "phpstan/phpstan": "^2.0",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^10.5",
+                "phpunit/phpunit": "^11.5",
+                "psr/http-message": "^2.0",
                 "rector/rector": "^2.0",
                 "vimeo/psalm": "^6.0"
             },
@@ -203,7 +202,7 @@
                     "homepage": "https://github.com/romm"
                 }
             ],
-            "description": "Library that helps to map any input into a strongly-typed value object structure.",
+            "description": "Dependency free PHP library that helps to map any input into a strongly-typed structure.",
             "homepage": "https://github.com/CuyZ/Valinor",
             "keywords": [
                 "array",
@@ -218,7 +217,7 @@
             ],
             "support": {
                 "issues": "https://github.com/CuyZ/Valinor/issues",
-                "source": "https://github.com/CuyZ/Valinor/tree/1.17.0"
+                "source": "https://github.com/CuyZ/Valinor/tree/2.5.0"
             },
             "funding": [
                 {
@@ -226,7 +225,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-06-20T06:40:38+00:00"
+            "time": "2026-06-28T21:53:40+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -3735,57 +3734,6 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
-        },
-        {
-            "name": "psr/simple-cache",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
-                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\SimpleCache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interfaces for simple caching",
-            "keywords": [
-                "cache",
-                "caching",
-                "psr",
-                "psr-16",
-                "simple-cache"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
-            },
-            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/src/Service/Feeds/Mapper/FeedConfigurationMapper.php
+++ b/src/Service/Feeds/Mapper/FeedConfigurationMapper.php
@@ -4,7 +4,6 @@ namespace App\Service\Feeds\Mapper;
 
 use App\Model\Feed\FeedConfiguration;
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\Mapper\Tree\Message\Messages;
 use CuyZ\Valinor\MapperBuilder;
 
 final class FeedConfigurationMapper
@@ -26,7 +25,9 @@ final class FeedConfigurationMapper
             return (new MapperBuilder())
                 ->allowPermissiveTypes()
                 ->allowSuperfluousKeys()
-                ->enableFlexibleCasting()
+                ->allowScalarValueCasting()
+                ->allowNonSequentialList()
+                ->allowUndefinedValues()
                 ->mapper()
                 ->map(
                     FeedConfiguration::class,
@@ -35,10 +36,7 @@ final class FeedConfigurationMapper
         } catch (MappingError $error) {
             // @todo: Log mapping error for later debugging.
             // Get flatten list of all messages through the whole nodes tree
-            $messages = Messages::flattenFromNode(
-                $error->node()
-            );
-            foreach ($messages as $message) {
+            foreach ($error->messages() as $message) {
                 echo $message,"\n";
             }
             throw $error;

--- a/src/Service/Feeds/Mapper/FeedMapper.php
+++ b/src/Service/Feeds/Mapper/FeedMapper.php
@@ -8,7 +8,6 @@ use App\Service\Feeds\FeedDefaultsMapper;
 use App\Service\Feeds\Mapper\Source\FeedItemSource;
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\Source\Source;
-use CuyZ\Valinor\Mapper\Tree\Message\Messages;
 use CuyZ\Valinor\MapperBuilder;
 use Psr\Log\LoggerInterface;
 
@@ -34,7 +33,9 @@ final readonly class FeedMapper implements FeedMapperInterface
         try {
             return (new MapperBuilder())
                 ->allowSuperfluousKeys()
-                ->enableFlexibleCasting()
+                ->allowScalarValueCasting()
+                ->allowNonSequentialList()
+                ->allowUndefinedValues()
                 ->supportDateFormats($configuration->dateFormat)
                 ->mapper()
                 ->map(
@@ -43,8 +44,7 @@ final readonly class FeedMapper implements FeedMapperInterface
                 );
         } catch (MappingError $error) {
             // Get flatten list of all messages through the whole nodes tree
-            $messages = Messages::flattenFromNode($error->node());
-            foreach ($messages as $message) {
+            foreach ($error->messages() as $message) {
                 $this->logger->error($message);
             }
             throw $error;

--- a/tests/Functional/Service/Feeds/FeedMapperTest.php
+++ b/tests/Functional/Service/Feeds/FeedMapperTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Service\Feeds;
+
+use App\Model\Feed\FeedConfiguration;
+use App\Service\Feeds\Mapper\FeedMapperInterface;
+use CuyZ\Valinor\Mapper\MappingError;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Guards the Valinor feed-item mapping behaviours that change across the
+ * 1.x → 2.x upgrade: scalar value casting and the MappingError branch. The
+ * timezone/date-format behaviour is covered by FeedMapperTimezoneTest.
+ */
+final class FeedMapperTest extends KernelTestCase
+{
+    private function mapper(): FeedMapperInterface
+    {
+        $mapper = self::getContainer()->get(FeedMapperInterface::class);
+        self::assertInstanceOf(FeedMapperInterface::class, $mapper);
+
+        return $mapper;
+    }
+
+    private function config(): FeedConfiguration
+    {
+        return new FeedConfiguration(
+            type: 'json',
+            url: 'https://example.test/feed',
+            base: 'https://example.test/',
+            timezone: 'Europe/Copenhagen',
+            rootPointer: '/-',
+            dateFormat: 'Y-m-d\TH:i:sP',
+            mapping: [
+                'id' => 'id',
+                'occurrences.*.start' => 'occurrences.*.start',
+                'occurrences.*.end' => 'occurrences.*.end',
+                'occurrences.*.price' => 'occurrences.*.price',
+            ],
+        );
+    }
+
+    /**
+     * Scalar value casting: a numeric price in the source is cast to the target
+     * string type. Guards the enableFlexibleCasting() -> allowScalarValueCasting()
+     * migration in Valinor 2.x.
+     */
+    public function testNumericPriceIsCastToString(): void
+    {
+        $data = [
+            'id' => 'evt-1',
+            'occurrences' => [[
+                'start' => '2026-08-15T20:45:00+02:00',
+                'end' => '2026-08-15T21:45:00+02:00',
+                'price' => 100,
+            ]],
+        ];
+
+        $item = $this->mapper()->getFeedItemFromArray($data, $this->config());
+
+        self::assertSame('evt-1', $item->id);
+        self::assertSame('100', $item->occurrences[0]->price);
+    }
+
+    /**
+     * The MappingError branch: a missing required id throws. Guards the
+     * Messages::flattenFromNode() -> MappingError::messages() migration.
+     */
+    public function testMissingRequiredIdThrowsMappingError(): void
+    {
+        $data = [
+            'occurrences' => [[
+                'start' => '2026-08-15T20:45:00+02:00',
+                'end' => '2026-08-15T21:45:00+02:00',
+            ]],
+        ];
+
+        $this->expectException(MappingError::class);
+
+        $this->mapper()->getFeedItemFromArray($data, $this->config());
+    }
+}

--- a/tests/Unit/Service/Feeds/Mapper/FeedConfigurationMapperTest.php
+++ b/tests/Unit/Service/Feeds/Mapper/FeedConfigurationMapperTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Feeds\Mapper;
+
+use App\Model\Feed\FeedConfiguration;
+use App\Service\Feeds\Mapper\FeedConfigurationMapper;
+use CuyZ\Valinor\Mapper\MappingError;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards the Valinor configuration mapping. These behaviours (scalar casting,
+ * superfluous keys, permissive types and the MappingError branch) exercise the
+ * exact MapperBuilder options that change across the Valinor 1.x → 2.x upgrade.
+ */
+#[CoversClass(FeedConfigurationMapper::class)]
+final class FeedConfigurationMapperTest extends TestCase
+{
+    private FeedConfigurationMapper $mapper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mapper = new FeedConfigurationMapper();
+    }
+
+    /**
+     * The shipped configuration template must map into a fully populated
+     * FeedConfiguration, including the nested pagination object.
+     */
+    public function testMapsTemplateConfiguration(): void
+    {
+        $config = $this->mapper->getConfigurationFromArray(FeedConfiguration::getConfigurationTemplate());
+
+        self::assertInstanceOf(FeedConfiguration::class, $config);
+        self::assertSame('json', $config->type);
+        self::assertSame('Europe/Copenhagen', $config->timezone);
+        self::assertSame("Y-m-d\TH:i:sP", $config->dateFormat);
+        self::assertArrayHasKey('id', $config->mapping);
+        self::assertNotNull($config->pagination);
+    }
+
+    /**
+     * allowSuperfluousKeys(): unknown top-level keys are ignored rather than
+     * raising a mapping error.
+     */
+    public function testSuperfluousKeysAreIgnored(): void
+    {
+        $data = $this->baseConfiguration();
+        $data['unknownKey'] = 'should-be-ignored';
+
+        $config = $this->mapper->getConfigurationFromArray($data);
+
+        self::assertSame('https://example.test/feed', $config->url);
+    }
+
+    /**
+     * Scalar value casting: numeric strings for the pagination page/limit are
+     * cast to int. This guards the enableFlexibleCasting() -> allowScalarValueCasting()
+     * migration in Valinor 2.x.
+     */
+    public function testNumericStringsAreCastToInt(): void
+    {
+        $data = $this->baseConfiguration();
+        $data['pagination'] = [
+            'pageParameter' => 'page',
+            'limitParameter' => 'limit',
+            'page' => '3',
+            'limit' => '25',
+        ];
+
+        $config = $this->mapper->getConfigurationFromArray($data);
+
+        self::assertNotNull($config->pagination);
+        self::assertSame(3, $config->pagination->page);
+        self::assertSame(25, $config->pagination->limit);
+    }
+
+    /**
+     * The MappingError branch: a missing required key throws. This guards the
+     * Messages::flattenFromNode() -> MappingError::messages() migration.
+     */
+    public function testMissingRequiredKeyThrowsMappingError(): void
+    {
+        $data = $this->baseConfiguration();
+        unset($data['url']);
+
+        $this->expectException(MappingError::class);
+
+        // The mapper echoes the flattened messages on failure; keep test output clean.
+        ob_start();
+        try {
+            $this->mapper->getConfigurationFromArray($data);
+        } finally {
+            ob_end_clean();
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function baseConfiguration(): array
+    {
+        return [
+            'type' => 'json',
+            'url' => 'https://example.test/feed',
+            'base' => 'https://example.test/',
+            'timezone' => 'Europe/Copenhagen',
+            'rootPointer' => '/-',
+            'dateFormat' => "Y-m-d\TH:i:sP",
+            'mapping' => [
+                'id' => 'id',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Upgrade cuyz/valinor from 1.17 to 2.5, migrating the two feed mappers off the APIs removed in 2.0.

## Changes

- Replace the removed `enableFlexibleCasting()` with its granular successors `allowScalarValueCasting()`, `allowNonSequentialList()`, and `allowUndefinedValues()` in `FeedMapper` and `FeedConfigurationMapper`.
- Swap the removed `Messages::flattenFromNode($error->node())` error handling for `MappingError::messages()` in both mappers; drop the now-unused `Messages` imports.
- Bump the `cuyz/valinor` constraint `^1.4` → `^2.0` (resolves to 2.5.0).
- Add regression tests ahead of the bump: `FeedConfigurationMapperTest` (unit) and `FeedMapperTest` (functional), covering scalar-casting and the `MappingError` branch of each mapper.

## Why

`cuyz/valinor` 2.0 is a major release that removes `enableFlexibleCasting()` and `Messages::flattenFromNode()`, both of which this repo used in the feed normalization mappers (ADR 004). The granular casting methods and `MappingError::messages()` are the documented 1.x → 2.x replacements and preserve behaviour. The new tests were written and verified green against 1.17 first, so they act as a genuine regression guard across the bump — `FeedConfigurationMapper` had no coverage at all beforehand.

Verified: full PHPUnit suite (178 passed, 427 assertions) and PHPStan (no errors). Remaining test deprecations are pre-existing `liip/imagine-bundle` notices, unrelated to this change.
