### PR TITLE
chore: broaden Rector config and apply across the codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-105](https://github.com/itk-dev/event-database-imports/pull/105)
+  Broaden the Rector config (PHP, Symfony, Doctrine, PHPUnit, code-quality sets) and apply it across src/ and tests/
 - [PR-104](https://github.com/itk-dev/event-database-imports/pull/104)
   Refresh README and CLAUDE docs for current tooling/CI, convert the network diagram to Mermaid, condense the changelog
 - [PR-103](https://github.com/itk-dev/event-database-imports/pull/103)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -75,7 +75,7 @@ parameters:
 		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
-			count: 2
+			count: 1
 			path: src/Command/Index/IndexListCommand.php
 
 		-
@@ -95,12 +95,6 @@ parameters:
 			identifier: ternary.condNotBoolean
 			count: 2
 			path: src/Command/User/AddUserCommand.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 1
-			path: src/Command/User/ChangePasswordCommand.php
 
 		-
 			message: '#^Parameter \#1 \$organization of method App\\Entity\\Event\:\:setOrganization\(\) expects App\\Entity\\Organization\|null, App\\Entity\\Organization\|false given\.$#'
@@ -145,12 +139,6 @@ parameters:
 			path: src/Entity/Organization.php
 
 		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 1
-			path: src/Entity/User.php
-
-		-
 			message: '#^Method App\\Entity\\User\:\:getMail\(\) should return string but returns string\|null\.$#'
 			identifier: return.type
 			count: 1
@@ -169,12 +157,6 @@ parameters:
 			path: src/Entity/User.php
 
 		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 1
-			path: src/EventSubscriber/EasyAdminSubscriber.php
-
-		-
 			message: '#^Call to function is_null\(\) with array\<string\> will always evaluate to false\.$#'
 			identifier: function.impossibleType
 			count: 1
@@ -187,28 +169,10 @@ parameters:
 			path: src/Factory/LocationFactory.php
 
 		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 1
-			path: src/Factory/LocationFactory.php
-
-		-
 			message: '#^Only booleans are allowed in an if condition, string\|null given\.$#'
 			identifier: if.condNotBoolean
 			count: 1
 			path: src/Factory/LocationFactory.php
-
-		-
-			message: '#^Variable \$values in empty\(\) always exists and is always falsy\.$#'
-			identifier: empty.variable
-			count: 1
-			path: src/Factory/LocationFactory.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 3
-			path: src/MessageHandler/FeedItemNormalizationHandler.php
 
 		-
 			message: '#^Call to function is_null\(\) with int will always evaluate to false\.$#'
@@ -227,12 +191,6 @@ parameters:
 			identifier: empty.notAllowed
 			count: 1
 			path: src/Service/Feeds/FeedDefaultsMapper.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 1
-			path: src/Service/Feeds/Mapper/Source/FeedItemSource.php
 
 		-
 			message: '#^Only booleans are allowed in an if condition, int\|false given\.$#'
@@ -451,12 +409,6 @@ parameters:
 			path: src/Service/TagsNormalizer.php
 
 		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 1
-			path: src/Service/TagsNormalizer.php
-
-		-
 			message: '#^Only booleans are allowed in a ternary operator condition, App\\Entity\\Tag\|null given\.$#'
 			identifier: ternary.condNotBoolean
 			count: 1
@@ -491,9 +443,3 @@ parameters:
 			identifier: if.condNotBoolean
 			count: 1
 			path: src/Utils/UriHelper.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 3
-			path: src/Utils/Validator.php

--- a/rector.php
+++ b/rector.php
@@ -2,18 +2,55 @@
 
 declare(strict_types=1);
 
+use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
+use Rector\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector;
 use Rector\Config\RectorConfig;
-use Rector\Doctrine\Set\DoctrineSetList;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
+use Rector\Symfony\Symfony73\Rector\Class_\ConstraintOptionsToNamedArgumentsRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ParamTypeByMethodCallTypeRector;
 
 return RectorConfig::configure()
     ->withPaths([
         __DIR__.'/src',
+        __DIR__.'/tests',
     ])
     ->withCache(__DIR__.'/var/cache/rector')
-    // Import management is left to php-cs-fixer (PostToolUse hook / coding
-    // standards), so Rector does not touch `use` statements.
-    // Applies Doctrine upgrade rules based on the installed ORM/DBAL versions.
-    ->withComposerBased(doctrine: true)
-    ->withSets([
-        DoctrineSetList::DOCTRINE_CODE_QUALITY,
+    // Coding style and import (`use`) management are owned by php-cs-fixer
+    // (PostToolUse hook / coding standards), so Rector does not touch them.
+    //
+    // Modernize to the language level declared in composer.json (PHP >= 8.4).
+    ->withPhpSets()
+    // Version-based upgrade + quality rules resolved from the installed package
+    // versions (Doctrine ORM 3 / DBAL 4, Symfony 7.4, PHPUnit 13).
+    ->withComposerBased(doctrine: true, symfony: true, phpunit: true)
+    // Convert any remaining annotations to native PHP attributes.
+    ->withAttributesSets(symfony: true, doctrine: true, phpunit: true)
+    ->withPreparedSets(
+        deadCode: true,
+        codeQuality: true,
+        typeDeclarations: true,
+        privatization: true,
+        instanceOf: true,
+        earlyReturn: true,
+        carbon: true,
+        doctrineCodeQuality: true,
+        symfonyCodeQuality: true,
+        phpunitCodeQuality: true,
+    )
+    ->withSkip([
+        // Rewrites `isset($obj->prop)` to a null comparison that accesses the
+        // property directly — unsafe when `$obj` itself is nullable.
+        IssetOnPropertyObjectToPropertyExistsRector::class,
+        // Flips isset()/type guards in ways that dropped variables and inverted
+        // occurrence null-checks (OccurrencesFactory, LocationFactory).
+        FlipTypeControlToUseExclusiveTypeRector::class,
+        // Turns constraint array options into named args, passing a
+        // TranslatableMessage to a `string|null` constructor parameter.
+        ConstraintOptionsToNamedArgumentsRector::class,
+        // Widened an EasyAdmin filter's `false` label type to `bool`, which the
+        // `setLabel(...|false|null)` signature rejects.
+        ParamTypeByMethodCallTypeRector::class,
+        // The team suppresses `method.unused` (see phpstan.dist.neon) rather than
+        // deleting; don't let Rector remove those private methods out from under it.
+        RemoveUnusedPrivateMethodRector::class,
     ]);

--- a/src/Asset/EasyAdminAssetPackage.php
+++ b/src/Asset/EasyAdminAssetPackage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Asset;
 
 use EasyCorp\Bundle\EasyAdminBundle\Asset\AssetPackage;

--- a/src/Command/Event/EventDeleteCommand.php
+++ b/src/Command/Event/EventDeleteCommand.php
@@ -22,7 +22,7 @@ class EventDeleteCommand extends Command
     public function __construct(
         private readonly EventRepository $eventRepository,
         private readonly FeedRepository $feedRepository,
-        private CacheManager $imageCacheManager,
+        private readonly CacheManager $imageCacheManager,
     ) {
         parent::__construct();
     }

--- a/src/Command/Feed/FeedListCommand.php
+++ b/src/Command/Feed/FeedListCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 final class FeedListCommand extends Command
 {
-    private const SELECTIONS = ['enabled', 'disabled', 'all'];
+    private const array SELECTIONS = ['enabled', 'disabled', 'all'];
 
     public function __construct(
         private readonly FeedConfigurationMapper $configurationMapper,

--- a/src/Command/Index/IndexCreateCommand.php
+++ b/src/Command/Index/IndexCreateCommand.php
@@ -33,9 +33,7 @@ final class IndexCreateCommand extends Command
                 InputArgument::IS_ARRAY,
                 'Indexes to create (separate multiple indexes with a space)',
                 IndexNames::values(),
-                function (CompletionInput $input): array {
-                    return array_filter(IndexNames::values(), fn ($item) => str_starts_with($item, $input->getCompletionValue()));
-                }
+                fn (CompletionInput $input): array => array_filter(IndexNames::values(), fn ($item): bool => str_starts_with((string) $item, $input->getCompletionValue()))
             )
         ;
     }

--- a/src/Command/Index/IndexDumpCommand.php
+++ b/src/Command/Index/IndexDumpCommand.php
@@ -34,9 +34,7 @@ final class IndexDumpCommand extends Command
                 InputArgument::IS_ARRAY,
                 'Indexes to dump (separate multiple indexes with a space)',
                 IndexNames::values(),
-                function (CompletionInput $input): array {
-                    return array_filter(IndexNames::values(), fn ($item) => str_starts_with($item, $input->getCompletionValue()));
-                }
+                fn (CompletionInput $input): array => array_filter(IndexNames::values(), fn ($item): bool => str_starts_with((string) $item, $input->getCompletionValue()))
             )
             ->addOption('path', null, InputOption::VALUE_OPTIONAL, 'Path to write data to', './src/DataFixtures/indexes');
     }

--- a/src/Command/Index/IndexListCommand.php
+++ b/src/Command/Index/IndexListCommand.php
@@ -29,7 +29,7 @@ class IndexListCommand extends Command
             $indicesData = $this->indexManager->getAll();
 
             // Check if indices data exists
-            if (empty($indicesData)) {
+            if ([] === $indicesData) {
                 $io->warning('No indices found in the Elasticsearch cluster.');
 
                 return Command::SUCCESS;
@@ -43,7 +43,7 @@ class IndexListCommand extends Command
                 $tableData[$indexName] = [
                     '#' => ++$count,
                     'Index' => $indexName,
-                    'Aliases' => !empty($index['aliases']) ? implode(', ', $index['aliases']) : '',
+                    'Aliases' => empty($index['aliases']) ? '' : implode(', ', $index['aliases']),
                     'Docs Count' => $index['docs.count'] ?? 'N/A',
                     'Status' => $index['status'] ?? 'unknown',
                 ];

--- a/src/Command/Index/IndexPopulateCommand.php
+++ b/src/Command/Index/IndexPopulateCommand.php
@@ -34,9 +34,7 @@ final class IndexPopulateCommand extends Command
                 InputArgument::IS_ARRAY,
                 'Indexes to create (separate multiple indexes with a space)',
                 IndexNames::values(),
-                function (CompletionInput $input): array {
-                    return array_filter(IndexNames::values(), fn ($item) => str_starts_with($item, $input->getCompletionValue()));
-                }
+                fn (CompletionInput $input): array => array_filter(IndexNames::values(), fn ($item): bool => str_starts_with((string) $item, $input->getCompletionValue()))
             )
             ->addOption('force', null, InputOption::VALUE_NONE, 'Force execution ignoring locks')
             ->addOption('id', null, InputOption::VALUE_OPTIONAL, 'Single table record id (try to populate single record)', -1)

--- a/src/Command/Index/IndexPurgeCommand.php
+++ b/src/Command/Index/IndexPurgeCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Command\Index;
 
 use App\Service\IndexManager;

--- a/src/Command/Schedule/ImportCommand.php
+++ b/src/Command/Schedule/ImportCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Command\Schedule;
 
 use App\Service\Feeds\Reader\FeedReader;

--- a/src/Command/Schedule/MonitorTrait.php
+++ b/src/Command/Schedule/MonitorTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Command\Schedule;
 
 use Psr\Log\LoggerInterface;

--- a/src/Command/User/AddUserCommand.php
+++ b/src/Command/User/AddUserCommand.php
@@ -103,7 +103,7 @@ final class AddUserCommand extends Command
      */
     protected function interact(InputInterface $input, OutputInterface $output): void
     {
-        if (null !== $input->getArgument('password') && null !== $input->getArgument('email') && null !== $input->getArgument('full-name')) {
+        if (!in_array(null, [$input->getArgument('password'), $input->getArgument('email'), $input->getArgument('full-name')], true)) {
             return;
         }
 

--- a/src/Command/User/ChangePasswordCommand.php
+++ b/src/Command/User/ChangePasswordCommand.php
@@ -48,7 +48,7 @@ class ChangePasswordCommand extends Command
         }
 
         $password = $io->askHidden('New Password?', function (string $password): string {
-            if (empty($password)) {
+            if ('' === $password || '0' === $password) {
                 throw new \RuntimeException('Password cannot be empty.');
             }
 

--- a/src/Command/User/ListUsersWithoutOrganizationCommand.php
+++ b/src/Command/User/ListUsersWithoutOrganizationCommand.php
@@ -52,7 +52,7 @@ final class ListUsersWithoutOrganizationCommand extends Command
             return Command::SUCCESS;
         }
 
-        $rows = array_map(fn ($user) => [
+        $rows = array_map(fn ($user): array => [
             $user->getId(),
             $user->getName(),
             $user->getMail(),

--- a/src/Controller/AcceptTermsController.php
+++ b/src/Controller/AcceptTermsController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller;
 
 use App\Entity\User;
@@ -11,17 +13,20 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Translation\TranslatableMessage;
 
-#[Route('/admin/accept-terms')]
 class AcceptTermsController extends AbstractController
 {
-    #[Route('/admin')]
+    public function __construct(private readonly EntityManagerInterface $entityManager)
+    {
+    }
+
+    #[Route('/admin/accept-terms/admin')]
     public function index(): Response
     {
         return $this->redirectToRoute('admin');
     }
 
-    #[Route('/', name: 'app_accept_terms')]
-    public function acceptTerms(Request $request, EntityManagerInterface $entityManager): Response
+    #[Route('/admin/accept-terms/', name: 'app_accept_terms')]
+    public function acceptTerms(Request $request): Response
     {
         $user = $this->getUser();
         assert($user instanceof User);
@@ -30,9 +35,9 @@ class AcceptTermsController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $user->setTermsAcceptedAt(new \DateTimeImmutable());
+            $user->setTermsAcceptedAt(\Carbon\CarbonImmutable::now());
 
-            $entityManager->flush();
+            $this->entityManager->flush();
 
             return $this->redirectToRoute('admin');
         }

--- a/src/Controller/Admin/AbstractBaseCrudController.php
+++ b/src/Controller/Admin/AbstractBaseCrudController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller\Admin;
 
 use App\Entity\User;
@@ -15,12 +17,14 @@ abstract class AbstractBaseCrudController extends AbstractCrudController
         return self::class;
     }
 
+    #[\Override]
     public function configureActions(Actions $actions): Actions
     {
         return parent::configureActions($actions)
             ->add(Crud::PAGE_INDEX, Action::DETAIL);
     }
 
+    #[\Override]
     protected function getUser(): User
     {
         $user = parent::getUser();

--- a/src/Controller/Admin/AddressCrudController.php
+++ b/src/Controller/Admin/AddressCrudController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller\Admin;
 
 use App\Entity\Address;
@@ -19,11 +21,13 @@ use Symfony\Component\Translation\TranslatableMessage;
 
 class AddressCrudController extends AbstractBaseCrudController
 {
+    #[\Override]
     public static function getEntityFqcn(): string
     {
         return Address::class;
     }
 
+    #[\Override]
     public function configureCrud(Crud $crud): Crud
     {
         return $crud
@@ -34,6 +38,7 @@ class AddressCrudController extends AbstractBaseCrudController
             ->setPageTitle('detail', new TranslatableMessage('admin.address.edit.title'));
     }
 
+    #[\Override]
     public function configureActions(Actions $actions): Actions
     {
         $actions = parent::configureActions($actions);
@@ -46,6 +51,7 @@ class AddressCrudController extends AbstractBaseCrudController
         return $actions;
     }
 
+    #[\Override]
     public function configureFields(string $pageName): iterable
     {
         return [
@@ -98,6 +104,7 @@ class AddressCrudController extends AbstractBaseCrudController
         ];
     }
 
+    #[\Override]
     public function configureFilters(Filters $filters): Filters
     {
         return $filters

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -35,6 +35,7 @@ class DashboardController extends AbstractDashboardController
     ) {
     }
 
+    #[\Override]
     public function index(): Response
     {
         $adminUrlGenerator = $this->container->get(AdminUrlGenerator::class);
@@ -50,6 +51,7 @@ class DashboardController extends AbstractDashboardController
         return $this->redirect($adminUrlGenerator->setController(EventCrudController::class)->generateUrl());
     }
 
+    #[\Override]
     public function configureDashboard(): Dashboard
     {
         return Dashboard::new()
@@ -58,6 +60,7 @@ class DashboardController extends AbstractDashboardController
             ->renderContentMaximized();
     }
 
+    #[\Override]
     public function configureMenuItems(): iterable
     {
         // My Content
@@ -96,6 +99,7 @@ class DashboardController extends AbstractDashboardController
             ->setPermission(UserRoles::ROLE_ADMIN->value);
     }
 
+    #[\Override]
     public function configureCrud(): Crud
     {
         // Default config for all cruds in this controller.
@@ -109,6 +113,7 @@ class DashboardController extends AbstractDashboardController
             ->setTimeFormat(self::TIME_FORMAT);
     }
 
+    #[\Override]
     public function configureUserMenu(UserInterface $user): UserMenu
     {
         assert($user instanceof User);
@@ -128,6 +133,7 @@ class DashboardController extends AbstractDashboardController
             ]);
     }
 
+    #[\Override]
     public function configureAssets(): Assets
     {
         return Assets::new()

--- a/src/Controller/Admin/EmbedImageController.php
+++ b/src/Controller/Admin/EmbedImageController.php
@@ -15,11 +15,13 @@ class EmbedImageController extends AbstractBaseCrudController
     {
     }
 
+    #[\Override]
     public static function getEntityFqcn(): string
     {
         return Image::class;
     }
 
+    #[\Override]
     public function configureFields(string $pageName): iterable
     {
         return [

--- a/src/Controller/Admin/EmbedOccurrenceCrudController.php
+++ b/src/Controller/Admin/EmbedOccurrenceCrudController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller\Admin;
 
 use App\Entity\Occurrence;
@@ -12,17 +14,20 @@ use Symfony\Component\Translation\TranslatableMessage;
 
 class EmbedOccurrenceCrudController extends AbstractBaseCrudController
 {
+    #[\Override]
     public static function getEntityFqcn(): string
     {
         return Occurrence::class;
     }
 
+    #[\Override]
     public function configureCrud(Crud $crud): Crud
     {
         return $crud
             ->setDefaultSort(['start' => Order::Ascending->value]);
     }
 
+    #[\Override]
     public function configureFields(string $pageName): iterable
     {
         return [

--- a/src/Controller/Admin/EventCrudController.php
+++ b/src/Controller/Admin/EventCrudController.php
@@ -37,11 +37,13 @@ class EventCrudController extends AbstractBaseCrudController
     ) {
     }
 
+    #[\Override]
     public static function getEntityFqcn(): string
     {
         return Event::class;
     }
 
+    #[\Override]
     public function createEntity(string $entityFqcn): Event
     {
         $event = new Event();
@@ -56,6 +58,7 @@ class EventCrudController extends AbstractBaseCrudController
         return $event;
     }
 
+    #[\Override]
     public function configureCrud(Crud $crud): Crud
     {
         return $crud
@@ -66,6 +69,7 @@ class EventCrudController extends AbstractBaseCrudController
             ->setPageTitle('detail', new TranslatableMessage('admin.event.edit.title'));
     }
 
+    #[\Override]
     public function configureActions(Actions $actions): Actions
     {
         $actions = parent::configureActions($actions);
@@ -77,6 +81,7 @@ class EventCrudController extends AbstractBaseCrudController
         return $actions;
     }
 
+    #[\Override]
     public function configureFields(string $pageName): iterable
     {
         yield FormField::addFieldset('Basic information')
@@ -201,6 +206,7 @@ class EventCrudController extends AbstractBaseCrudController
             ->hideWhenCreating();
     }
 
+    #[\Override]
     public function configureFilters(Filters $filters): Filters
     {
         if ($this->isGranted(UserRoles::ROLE_EDITOR->value)) {
@@ -234,6 +240,7 @@ class EventCrudController extends AbstractBaseCrudController
      * for the fields on the page. However, when using "renderAsEmbeddedForm", js
      * for the fields in that controller is not added, so we have to that manually.
      */
+    #[\Override]
     protected function getFieldAssets(FieldCollection $fieldDtos): AssetsDto
     {
         $fieldAssetsDto = parent::getFieldAssets($fieldDtos);

--- a/src/Controller/Admin/FeedCrudController.php
+++ b/src/Controller/Admin/FeedCrudController.php
@@ -20,11 +20,13 @@ use Symfony\Component\Validator\Constraints\Json;
 
 class FeedCrudController extends AbstractBaseCrudController
 {
+    #[\Override]
     public static function getEntityFqcn(): string
     {
         return Feed::class;
     }
 
+    #[\Override]
     public function configureCrud(Crud $crud): Crud
     {
         return $crud
@@ -32,6 +34,7 @@ class FeedCrudController extends AbstractBaseCrudController
         ;
     }
 
+    #[\Override]
     public function configureActions(Actions $actions): Actions
     {
         $actions = parent::configureActions($actions);
@@ -46,6 +49,7 @@ class FeedCrudController extends AbstractBaseCrudController
         return $actions;
     }
 
+    #[\Override]
     public function configureFields(string $pageName): iterable
     {
         return [

--- a/src/Controller/Admin/FeedItemCrudController.php
+++ b/src/Controller/Admin/FeedItemCrudController.php
@@ -18,11 +18,13 @@ use Symfony\Component\Translation\TranslatableMessage;
 
 class FeedItemCrudController extends AbstractBaseCrudController
 {
+    #[\Override]
     public static function getEntityFqcn(): string
     {
         return FeedItem::class;
     }
 
+    #[\Override]
     public function configureCrud(Crud $crud): Crud
     {
         return $crud
@@ -31,6 +33,7 @@ class FeedItemCrudController extends AbstractBaseCrudController
         ;
     }
 
+    #[\Override]
     public function configureActions(Actions $actions): Actions
     {
         $actions = parent::configureActions($actions);
@@ -43,6 +46,7 @@ class FeedItemCrudController extends AbstractBaseCrudController
         return $actions;
     }
 
+    #[\Override]
     public function configureFields(string $pageName): iterable
     {
         return [
@@ -65,14 +69,13 @@ class FeedItemCrudController extends AbstractBaseCrudController
                 ->setFormat(DashboardController::DATETIME_FORMAT),
             CodeEditorField::new('data')
                 ->setLabel(new TranslatableMessage('admin.feeditem.data'))
-                ->formatValue(function ($value) {
-                    return json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
-                })
+                ->formatValue(fn ($value): string|false => json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE))
                 ->setLanguage('js')
                 ->hideOnIndex(),
         ];
     }
 
+    #[\Override]
     public function configureFilters(Filters $filters): Filters
     {
         if ($this->isGranted(UserRoles::ROLE_EDITOR->value)) {

--- a/src/Controller/Admin/LocationCrudController.php
+++ b/src/Controller/Admin/LocationCrudController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller\Admin;
 
 use App\Entity\Location;
@@ -22,11 +24,13 @@ use Symfony\Component\Translation\TranslatableMessage;
 
 class LocationCrudController extends AbstractBaseCrudController
 {
+    #[\Override]
     public static function getEntityFqcn(): string
     {
         return Location::class;
     }
 
+    #[\Override]
     public function configureCrud(Crud $crud): Crud
     {
         return $crud
@@ -37,6 +41,7 @@ class LocationCrudController extends AbstractBaseCrudController
             ->setPageTitle('detail', new TranslatableMessage('admin.location.edit.title'));
     }
 
+    #[\Override]
     public function configureActions(Actions $actions): Actions
     {
         $actions = parent::configureActions($actions);
@@ -49,6 +54,7 @@ class LocationCrudController extends AbstractBaseCrudController
         return $actions;
     }
 
+    #[\Override]
     public function configureFields(string $pageName): iterable
     {
         return [
@@ -97,6 +103,7 @@ class LocationCrudController extends AbstractBaseCrudController
         ];
     }
 
+    #[\Override]
     public function configureFilters(Filters $filters): Filters
     {
         return $filters

--- a/src/Controller/Admin/MyEventCrudController.php
+++ b/src/Controller/Admin/MyEventCrudController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller\Admin;
 
 use Doctrine\ORM\QueryBuilder;
@@ -14,6 +16,7 @@ use Symfony\Component\Translation\TranslatableMessage;
 
 class MyEventCrudController extends EventCrudController
 {
+    #[\Override]
     public function configureCrud(Crud $crud): Crud
     {
         $crud = parent::configureCrud($crud);
@@ -25,6 +28,7 @@ class MyEventCrudController extends EventCrudController
             ->setPageTitle('detail', new TranslatableMessage('admin.my.event.edit.title'));
     }
 
+    #[\Override]
     public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder
     {
         $qb = parent::createIndexQueryBuilder($searchDto, $entityDto, $fields, $filters);
@@ -35,6 +39,7 @@ class MyEventCrudController extends EventCrudController
         return $qb;
     }
 
+    #[\Override]
     public function configureFilters(Filters $filters): Filters
     {
         $choices = $this->getOrganizationChoices();

--- a/src/Controller/Admin/MyOrganizationCrudController.php
+++ b/src/Controller/Admin/MyOrganizationCrudController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller\Admin;
 
 use Doctrine\ORM\QueryBuilder;
@@ -12,6 +14,7 @@ use Symfony\Component\Translation\TranslatableMessage;
 
 class MyOrganizationCrudController extends OrganizationCrudController
 {
+    #[\Override]
     public function configureCrud(Crud $crud): Crud
     {
         $crud = parent::configureCrud($crud);
@@ -22,6 +25,7 @@ class MyOrganizationCrudController extends OrganizationCrudController
             ->setPageTitle('detail', new TranslatableMessage('admin.my.organizer.edit.title'));
     }
 
+    #[\Override]
     public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder
     {
         $qb = parent::createIndexQueryBuilder($searchDto, $entityDto, $fields, $filters);

--- a/src/Controller/Admin/OrganizationCrudController.php
+++ b/src/Controller/Admin/OrganizationCrudController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller\Admin;
 
 use App\Entity\Organization;
@@ -19,11 +21,13 @@ use Symfony\Component\Translation\TranslatableMessage;
 
 class OrganizationCrudController extends AbstractBaseCrudController
 {
+    #[\Override]
     public static function getEntityFqcn(): string
     {
         return Organization::class;
     }
 
+    #[\Override]
     public function configureCrud(Crud $crud): Crud
     {
         return $crud
@@ -34,6 +38,7 @@ class OrganizationCrudController extends AbstractBaseCrudController
             ->setPageTitle('detail', new TranslatableMessage('admin.organizer.edit.title'));
     }
 
+    #[\Override]
     public function configureActions(Actions $actions): Actions
     {
         $actions = parent::configureActions($actions);
@@ -45,6 +50,7 @@ class OrganizationCrudController extends AbstractBaseCrudController
         return $actions;
     }
 
+    #[\Override]
     public function configureFields(string $pageName): iterable
     {
         return [
@@ -71,6 +77,7 @@ class OrganizationCrudController extends AbstractBaseCrudController
         ];
     }
 
+    #[\Override]
     public function configureFilters(Filters $filters): Filters
     {
         return $filters

--- a/src/Controller/Admin/TagCrudController.php
+++ b/src/Controller/Admin/TagCrudController.php
@@ -14,11 +14,13 @@ use Symfony\Component\Translation\TranslatableMessage;
 
 class TagCrudController extends AbstractBaseCrudController
 {
+    #[\Override]
     public static function getEntityFqcn(): string
     {
         return Tag::class;
     }
 
+    #[\Override]
     public function configureCrud(Crud $crud): Crud
     {
         return $crud
@@ -27,6 +29,7 @@ class TagCrudController extends AbstractBaseCrudController
             ->showEntityActionsInlined();
     }
 
+    #[\Override]
     public function configureFields(string $pageName): iterable
     {
         return [
@@ -50,6 +53,7 @@ class TagCrudController extends AbstractBaseCrudController
         ];
     }
 
+    #[\Override]
     public function configureFilters(Filters $filters): Filters
     {
         $filters

--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -42,11 +42,13 @@ class UserCrudController extends AbstractBaseCrudController
     ) {
     }
 
+    #[\Override]
     public static function getEntityFqcn(): string
     {
         return User::class;
     }
 
+    #[\Override]
     public function configureCrud(Crud $crud): Crud
     {
         return parent::configureCrud($crud)
@@ -56,6 +58,7 @@ class UserCrudController extends AbstractBaseCrudController
             ->setPageTitle('detail', new TranslatableMessage('admin.user.edit.title'));
     }
 
+    #[\Override]
     public function configureActions(Actions $actions): Actions
     {
         $actions = parent::configureActions($actions);
@@ -68,6 +71,7 @@ class UserCrudController extends AbstractBaseCrudController
         return $actions;
     }
 
+    #[\Override]
     public function configureFilters(Filters $filters): Filters
     {
         $userRolesChoices = [];
@@ -84,6 +88,7 @@ class UserCrudController extends AbstractBaseCrudController
         ;
     }
 
+    #[\Override]
     public function configureFields(string $pageName): iterable
     {
         $userRolesChoices = [
@@ -159,6 +164,7 @@ class UserCrudController extends AbstractBaseCrudController
         ];
     }
 
+    #[\Override]
     public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder
     {
         $qb = parent::createIndexQueryBuilder($searchDto, $entityDto, $fields, $filters);
@@ -170,6 +176,7 @@ class UserCrudController extends AbstractBaseCrudController
         return $qb;
     }
 
+    #[\Override]
     public function createNewFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface
     {
         $formBuilder = parent::createNewFormBuilder($entityDto, $formOptions, $context);
@@ -177,6 +184,7 @@ class UserCrudController extends AbstractBaseCrudController
         return $this->addPasswordEventListener($formBuilder);
     }
 
+    #[\Override]
     public function createEditFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface
     {
         $formBuilder = parent::createEditFormBuilder($entityDto, $formOptions, $context);
@@ -194,7 +202,7 @@ class UserCrudController extends AbstractBaseCrudController
      */
     private function hashPassword(): \Closure
     {
-        return function ($event) {
+        return function ($event): void {
             $form = $event->getForm();
             if (!$form->isValid()) {
                 return;

--- a/src/Controller/Admin/VocabularyCrudController.php
+++ b/src/Controller/Admin/VocabularyCrudController.php
@@ -18,11 +18,13 @@ use Symfony\Component\Translation\TranslatableMessage;
 
 class VocabularyCrudController extends AbstractBaseCrudController
 {
+    #[\Override]
     public static function getEntityFqcn(): string
     {
         return Vocabulary::class;
     }
 
+    #[\Override]
     public function configureCrud(Crud $crud): Crud
     {
         return $crud
@@ -34,6 +36,7 @@ class VocabularyCrudController extends AbstractBaseCrudController
             ->setPageTitle('detail', new TranslatableMessage('admin.vocabulary.edit.title'));
     }
 
+    #[\Override]
     public function configureActions(Actions $actions): Actions
     {
         $actions = parent::configureActions($actions);
@@ -48,6 +51,7 @@ class VocabularyCrudController extends AbstractBaseCrudController
         return $actions;
     }
 
+    #[\Override]
     public function configureFields(string $pageName): iterable
     {
         return [
@@ -55,10 +59,10 @@ class VocabularyCrudController extends AbstractBaseCrudController
                 ->setLabel(new TranslatableMessage('admin.vocabulary.name')),
             AssociationField::new('tags')
                 ->setQueryBuilder(
-                    fn (QueryBuilder $queryBuilder) => $queryBuilder->addCriteria(
+                    fn (QueryBuilder $queryBuilder): QueryBuilder => $queryBuilder->addCriteria(
                         // accessRawFieldValues is the collections 3.0 default; no effect here as the
                         // criteria only orders, but it avoids the 2.x deprecation.
-                        (new Criteria(accessRawFieldValues: true))->orderBy(['name' => Order::Ascending])
+                        new Criteria(accessRawFieldValues: true)->orderBy(['name' => Order::Ascending])
                     )
                 )
                 ->setLabel(new TranslatableMessage('admin.vocabulary.tags')),

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -19,7 +19,6 @@ use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailExceptionInterface;
 
-#[Route('/admin/register')]
 class RegistrationController extends AbstractController
 {
     public function __construct(
@@ -28,17 +27,20 @@ class RegistrationController extends AbstractController
         private readonly string $siteSendFromEmail,
         private readonly string $siteReplyToEmail,
         private readonly string $siteName,
+        private readonly UserPasswordHasherInterface $userPasswordHasher,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly TranslatorInterface $translator,
     ) {
     }
 
-    #[Route('/admin')]
+    #[Route('/admin/register/admin')]
     public function index(): Response
     {
         return $this->redirectToRoute('admin');
     }
 
-    #[Route('/', name: 'app_register')]
-    public function register(Request $request, UserPasswordHasherInterface $userPasswordHasher, EntityManagerInterface $entityManager, TranslatorInterface $translator): Response
+    #[Route('/admin/register/', name: 'app_register')]
+    public function register(Request $request): Response
     {
         $user = new User();
         $form = $this->createForm(RegistrationFormType::class, $user);
@@ -47,27 +49,27 @@ class RegistrationController extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             // encode the plain password
             $user->setPassword(
-                $userPasswordHasher->hashPassword(
+                $this->userPasswordHasher->hashPassword(
                     $user,
                     $form->get('plainPassword')->getData()
                 )
             );
 
-            $user->setTermsAcceptedAt(new \DateTimeImmutable());
+            $user->setTermsAcceptedAt(\Carbon\CarbonImmutable::now());
             $user->setRoles([UserRoles::ROLE_USER]);
             $user->setCreatedBy($user->getName());
             $user->setUpdatedBy($user->getName());
 
-            $entityManager->persist($user);
-            $entityManager->flush();
+            $this->entityManager->persist($user);
+            $this->entityManager->flush();
 
             // generate a signed url and email it to the user
             $this->emailVerifier->sendEmailConfirmation('app_verify_email', $user,
-                (new TemplatedEmail())
+                new TemplatedEmail()
                     ->from(new Address($this->siteSendFromEmail, $this->siteName))
                     ->replyTo(new Address($this->siteReplyToEmail, $this->siteName))
                     ->to($user->getMail())
-                    ->subject($translator->trans('registration.page.confirm_email', [], 'messages'))
+                    ->subject($this->translator->trans('registration.page.confirm_email', [], 'messages'))
                     ->htmlTemplate('app/registration/confirmation_email.html.twig')
             );
 
@@ -89,8 +91,8 @@ class RegistrationController extends AbstractController
         ]);
     }
 
-    #[Route('/verify-email', name: 'app_verify_email')]
-    public function verifyUserEmail(Request $request, TranslatorInterface $translator): Response
+    #[Route('/admin/register/verify-email', name: 'app_verify_email')]
+    public function verifyUserEmail(Request $request): Response
     {
         $id = $request->query->get('id');
 
@@ -110,7 +112,7 @@ class RegistrationController extends AbstractController
         try {
             $this->emailVerifier->handleEmailConfirmation($request, $user);
         } catch (VerifyEmailExceptionInterface $exception) {
-            $this->addFlash('verify_email_error', $translator->trans($exception->getReason(), [], 'VerifyEmailBundle'));
+            $this->addFlash('verify_email_error', $this->translator->trans($exception->getReason(), [], 'VerifyEmailBundle'));
 
             return $this->redirectToRoute('app_register');
         }

--- a/src/DataFixtures/AddressFixture.php
+++ b/src/DataFixtures/AddressFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\DataFixtures;
 
 use App\Entity\Address;
@@ -8,7 +10,7 @@ use Doctrine\Persistence\ObjectManager;
 
 final class AddressFixture extends Fixture
 {
-    public const ITKDEV = 'address-itkdev';
+    public const string ITKDEV = 'address-itkdev';
 
     public function load(ObjectManager $manager): void
     {

--- a/src/DataFixtures/EventFixture.php
+++ b/src/DataFixtures/EventFixture.php
@@ -18,8 +18,8 @@ use Doctrine\Persistence\ObjectManager;
  */
 final class EventFixture extends Fixture implements DependentFixtureInterface
 {
-    public const EVENT1 = 'event1-itkdev';
-    public const EVENT2 = 'event2-itkdev';
+    public const string EVENT1 = 'event1-itkdev';
+    public const string EVENT2 = 'event2-itkdev';
 
     public function load(ObjectManager $manager): void
     {

--- a/src/DataFixtures/ImagesFixtures.php
+++ b/src/DataFixtures/ImagesFixtures.php
@@ -9,8 +9,8 @@ use Doctrine\Persistence\ObjectManager;
 
 final class ImagesFixtures extends Fixture
 {
-    public const AAK = 'image_aak';
-    public const ITK = 'image_itk';
+    public const string AAK = 'image_aak';
+    public const string ITK = 'image_itk';
 
     public function __construct(
         private readonly ImageServiceInterface $imageHandler,

--- a/src/DataFixtures/LocationFixture.php
+++ b/src/DataFixtures/LocationFixture.php
@@ -10,7 +10,7 @@ use Doctrine\Persistence\ObjectManager;
 
 final class LocationFixture extends Fixture implements DependentFixtureInterface
 {
-    public const ITKDEV = 'location-itkdev';
+    public const string ITKDEV = 'location-itkdev';
 
     public function load(ObjectManager $manager): void
     {

--- a/src/DataFixtures/OccurrenceFixture.php
+++ b/src/DataFixtures/OccurrenceFixture.php
@@ -10,9 +10,9 @@ use Doctrine\Persistence\ObjectManager;
 
 final class OccurrenceFixture extends Fixture implements DependentFixtureInterface
 {
-    public const OCCURRENCE_241207 = 'OCCURRENCE_241207';
-    public const OCCURRENCE_241108 = 'OCCURRENCE_241108';
-    public const OCCURRENCE_241208 = 'OCCURRENCE_241208';
+    public const string OCCURRENCE_241207 = 'OCCURRENCE_241207';
+    public const string OCCURRENCE_241108 = 'OCCURRENCE_241108';
+    public const string OCCURRENCE_241208 = 'OCCURRENCE_241208';
 
     public function load(ObjectManager $manager): void
     {

--- a/src/DataFixtures/OrganizationFixtures.php
+++ b/src/DataFixtures/OrganizationFixtures.php
@@ -10,9 +10,9 @@ use Doctrine\Persistence\ObjectManager;
 
 final class OrganizationFixtures extends Fixture implements DependentFixtureInterface
 {
-    public const ITK = 'itk';
-    public const AAKB = 'aakb';
-    public const DOKK1 = 'dokk1';
+    public const string ITK = 'itk';
+    public const string AAKB = 'aakb';
+    public const string DOKK1 = 'dokk1';
 
     public function load(ObjectManager $manager): void
     {

--- a/src/DataFixtures/TagsFixtures.php
+++ b/src/DataFixtures/TagsFixtures.php
@@ -10,11 +10,11 @@ use Doctrine\Persistence\ObjectManager;
 
 final class TagsFixtures extends Fixture implements DependentFixtureInterface
 {
-    public const CONCERT = 'tags_concert';
-    public const KIDS = 'tags_kids';
-    public const RACE = 'tags_race';
-    public const AROS = 'tags_aros';
-    public const ITKDEV = 'tags_itkdev';
+    public const string CONCERT = 'tags_concert';
+    public const string KIDS = 'tags_kids';
+    public const string RACE = 'tags_race';
+    public const string AROS = 'tags_aros';
+    public const string ITKDEV = 'tags_itkdev';
 
     public function load(ObjectManager $manager): void
     {

--- a/src/DataFixtures/UserFixtures.php
+++ b/src/DataFixtures/UserFixtures.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\DataFixtures;
 
 use App\Entity\User;
@@ -9,8 +11,8 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 final class UserFixtures extends Fixture
 {
-    public const ADMIN_USER = 'admin';
-    public const USER = 'user';
+    public const string ADMIN_USER = 'admin';
+    public const string USER = 'user';
 
     public function __construct(
         private readonly UserPasswordHasherInterface $passwordHasher,

--- a/src/DataFixtures/VocabularyFixtures.php
+++ b/src/DataFixtures/VocabularyFixtures.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\DataFixtures;
 
 use App\Entity\Vocabulary;
@@ -8,8 +10,8 @@ use Doctrine\Persistence\ObjectManager;
 
 final class VocabularyFixtures extends Fixture
 {
-    public const MANAGED = 'managed';
-    public const FREE = 'free';
+    public const string MANAGED = 'managed';
+    public const string FREE = 'free';
 
     public function load(ObjectManager $manager): void
     {

--- a/src/Doctrine/Extensions/DBAL/Types/UTCDateTimeImmutableType.php
+++ b/src/Doctrine/Extensions/DBAL/Types/UTCDateTimeImmutableType.php
@@ -10,17 +10,17 @@ class UTCDateTimeImmutableType extends DateTimeImmutableType
 {
     private static ?\DateTimeZone $utc = null;
 
+    #[\Override]
     public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
     {
-        if ($value instanceof \DateTimeImmutable) {
-            if (self::getUtc()->getName() !== $value->getTimezone()->getName()) {
-                $value = $value->setTimezone(self::getUtc());
-            }
+        if ($value instanceof \DateTimeImmutable && $this->getUtc()->getName() !== $value->getTimezone()->getName()) {
+            $value = $value->setTimezone($this->getUtc());
         }
 
         return parent::convertToDatabaseValue($value, $platform);
     }
 
+    #[\Override]
     public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?\DateTimeImmutable
     {
         if (null === $value || $value instanceof \DateTimeImmutable) {
@@ -30,7 +30,7 @@ class UTCDateTimeImmutableType extends DateTimeImmutableType
         $converted = \DateTimeImmutable::createFromFormat(
             $platform->getDateTimeFormatString(),
             $value,
-            self::getUtc()
+            $this->getUtc()
         );
 
         if (false === $converted) {
@@ -40,7 +40,7 @@ class UTCDateTimeImmutableType extends DateTimeImmutableType
         return $converted;
     }
 
-    private static function getUtc(): \DateTimeZone
+    private function getUtc(): \DateTimeZone
     {
         return self::$utc ??= new \DateTimeZone('UTC');
     }

--- a/src/Doctrine/Extensions/DBAL/Types/UTCDateTimeType.php
+++ b/src/Doctrine/Extensions/DBAL/Types/UTCDateTimeType.php
@@ -10,20 +10,20 @@ class UTCDateTimeType extends DateTimeType
 {
     private static ?\DateTimeZone $utc = null;
 
+    #[\Override]
     public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
     {
-        if ($value instanceof \DateTime) {
-            if (self::getUtc()->getName() !== $value->getTimezone()->getName()) {
-                // Clone before converting: \DateTime is mutable and the caller
-                // (the entity) still owns this object — its timezone must not be
-                // silently rewritten as a side effect of persisting.
-                $value = (clone $value)->setTimezone(self::getUtc());
-            }
+        if ($value instanceof \DateTime && $this->getUtc()->getName() !== $value->getTimezone()->getName()) {
+            // Clone before converting: \DateTime is mutable and the caller
+            // (the entity) still owns this object — its timezone must not be
+            // silently rewritten as a side effect of persisting.
+            $value = (clone $value)->setTimezone($this->getUtc());
         }
 
         return parent::convertToDatabaseValue($value, $platform);
     }
 
+    #[\Override]
     public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?\DateTime
     {
         if (null === $value || $value instanceof \DateTime) {
@@ -33,7 +33,7 @@ class UTCDateTimeType extends DateTimeType
         $converted = \DateTime::createFromFormat(
             $platform->getDateTimeFormatString(),
             $value,
-            self::getUtc()
+            $this->getUtc()
         );
 
         if (false === $converted) {
@@ -43,7 +43,7 @@ class UTCDateTimeType extends DateTimeType
         return $converted;
     }
 
-    private static function getUtc(): \DateTimeZone
+    private function getUtc(): \DateTimeZone
     {
         return self::$utc ??= new \DateTimeZone('UTC');
     }

--- a/src/EasyAdmin/DateTimeFieldConfigurator.php
+++ b/src/EasyAdmin/DateTimeFieldConfigurator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\EasyAdmin;
 
 use App\Controller\Admin\DashboardController;
@@ -15,10 +17,14 @@ class DateTimeFieldConfigurator implements FieldConfiguratorInterface
 {
     public function supports(FieldDto $field, EntityDto $entityDto): bool
     {
-        return
-            DateTimeField::class === $field->getFieldFqcn()
-            || DateField::class === $field->getFieldFqcn()
-            || TimeField::class === $field->getFieldFqcn();
+        if (DateTimeField::class === $field->getFieldFqcn()) {
+            return true;
+        }
+        if (DateField::class === $field->getFieldFqcn()) {
+            return true;
+        }
+
+        return TimeField::class === $field->getFieldFqcn();
     }
 
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void

--- a/src/EasyAdmin/DateTimeFilterConfigurator.php
+++ b/src/EasyAdmin/DateTimeFilterConfigurator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\EasyAdmin;
 
 use App\Controller\Admin\DashboardController;

--- a/src/EasyAdmin/Filter/HasOrganizationFilter.php
+++ b/src/EasyAdmin/Filter/HasOrganizationFilter.php
@@ -22,8 +22,8 @@ final class HasOrganizationFilter implements FilterInterface
      */
     public static function new(string $associationProperty, $label = null): self
     {
-        $filter = (new self())
-            ->setFilterFqcn(__CLASS__)
+        $filter = new self()
+            ->setFilterFqcn(self::class)
             ->setProperty('hasOrganization')
             ->setLabel($label)
             ->setFormType(BooleanFilterType::class)

--- a/src/EasyAdmin/Filter/JsonContainsFilter.php
+++ b/src/EasyAdmin/Filter/JsonContainsFilter.php
@@ -20,8 +20,8 @@ final class JsonContainsFilter implements FilterInterface
      */
     public static function new(string $propertyName, $label = null): self
     {
-        return (new self())
-            ->setFilterFqcn(__CLASS__)
+        return new self()
+            ->setFilterFqcn(self::class)
             ->setProperty($propertyName)
             ->setLabel($label)
             ->setFormType(ChoiceFilterType::class)
@@ -44,7 +44,7 @@ final class JsonContainsFilter implements FilterInterface
     public function setTranslatableChoices(array $choiceGenerator): self
     {
         $this->dto->setFormTypeOption('value_type_options.choices', array_keys($choiceGenerator));
-        $this->dto->setFormTypeOption('value_type_options.choice_label', fn ($value) => $choiceGenerator[$value]);
+        $this->dto->setFormTypeOption('value_type_options.choice_label', fn ($value): TranslatableInterface => $choiceGenerator[$value]);
 
         return $this;
     }

--- a/src/Entity/Address.php
+++ b/src/Entity/Address.php
@@ -18,7 +18,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
     fields: ['street', 'postalCode'],
     message: 'entity.address.street_postcode.not_unique'
 )]
-class Address implements EditableEntityInterface
+class Address implements EditableEntityInterface, \Stringable
 {
     use TimestampableEntity;
     use SoftDeleteableEntity;
@@ -57,7 +57,7 @@ class Address implements EditableEntityInterface
     #[Groups([IndexNames::Events->value, IndexNames::Locations->value])]
     private ?float $longitude = null;
 
-    #[ORM\OneToMany(mappedBy: 'address', targetEntity: Location::class)]
+    #[ORM\OneToMany(targetEntity: Location::class, mappedBy: 'address')]
     private Collection $locations;
 
     #[ORM\Column]
@@ -191,11 +191,9 @@ class Address implements EditableEntityInterface
 
     public function removeLocation(Location $location): static
     {
-        if ($this->locations->removeElement($location)) {
-            // set the owning side to null (unless already changed)
-            if ($location->getAddress() === $this) {
-                $location->setAddress(null);
-            }
+        // set the owning side to null (unless already changed)
+        if ($this->locations->removeElement($location) && $location->getAddress() === $this) {
+            $location->setAddress(null);
         }
 
         return $this;

--- a/src/Entity/DailyOccurrence.php
+++ b/src/Entity/DailyOccurrence.php
@@ -13,7 +13,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\SerializedPath;
 
 #[ORM\Entity(repositoryClass: DailyOccurrenceRepository::class)]
-class DailyOccurrence implements IndexItemInterface
+class DailyOccurrence implements IndexItemInterface, \Stringable
 {
     use TimestampableEntity;
     use SoftDeleteableEntity;

--- a/src/Entity/EditableEntityInterface.php
+++ b/src/Entity/EditableEntityInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Entity;
 
 interface EditableEntityInterface

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -17,7 +17,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\SerializedPath;
 
 #[ORM\Entity(repositoryClass: EventRepository::class)]
-class Event implements IndexItemInterface, EditableEntityInterface
+class Event implements IndexItemInterface, EditableEntityInterface, \Stringable
 {
     use TimestampableEntity;
     use SoftDeleteableEntity;
@@ -74,11 +74,11 @@ class Event implements IndexItemInterface, EditableEntityInterface
     #[ORM\OneToOne(mappedBy: 'event', cascade: ['persist', 'remove'])]
     private ?FeedItem $feedItem = null;
 
-    #[ORM\OneToMany(mappedBy: 'event', targetEntity: Occurrence::class, cascade: ['persist'], orphanRemoval: true)]
+    #[ORM\OneToMany(targetEntity: Occurrence::class, mappedBy: 'event', cascade: ['persist'], orphanRemoval: true)]
     #[Groups([IndexNames::Events->value])]
     private Collection $occurrences;
 
-    #[ORM\OneToMany(mappedBy: 'event', targetEntity: DailyOccurrence::class, cascade: ['persist'], orphanRemoval: true)]
+    #[ORM\OneToMany(targetEntity: DailyOccurrence::class, mappedBy: 'event', cascade: ['persist'], orphanRemoval: true)]
     #[Groups([IndexNames::Events->value])]
     private Collection $dailyOccurrences;
 
@@ -244,11 +244,9 @@ class Event implements IndexItemInterface, EditableEntityInterface
 
     public function removeOccurrence(Occurrence $occurrence): static
     {
-        if ($this->occurrences->removeElement($occurrence)) {
-            // set the owning side to null (unless already changed)
-            if ($occurrence->getEvent() === $this) {
-                $occurrence->setEvent(null);
-            }
+        // set the owning side to null (unless already changed)
+        if ($this->occurrences->removeElement($occurrence) && $occurrence->getEvent() === $this) {
+            $occurrence->setEvent(null);
         }
 
         return $this;
@@ -274,11 +272,9 @@ class Event implements IndexItemInterface, EditableEntityInterface
 
     public function removeDailyOccurrence(DailyOccurrence $dailyOccurrence): static
     {
-        if ($this->dailyOccurrences->removeElement($dailyOccurrence)) {
-            // set the owning side to null (unless already changed)
-            if ($dailyOccurrence->getEvent() === $this) {
-                $dailyOccurrence->setEvent(null);
-            }
+        // set the owning side to null (unless already changed)
+        if ($this->dailyOccurrences->removeElement($dailyOccurrence) && $dailyOccurrence->getEvent() === $this) {
+            $dailyOccurrence->setEvent(null);
         }
 
         return $this;

--- a/src/Entity/Feed.php
+++ b/src/Entity/Feed.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 #[ORM\Entity(repositoryClass: FeedRepository::class)]
 #[ORM\HasLifecycleCallbacks]
-class Feed
+class Feed implements \Stringable
 {
     use TimestampableEntity;
     use BlameableEntity;
@@ -42,7 +42,7 @@ class Feed
     #[ORM\ManyToOne(inversedBy: 'feeds')]
     private ?User $user = null;
 
-    #[ORM\OneToMany(mappedBy: 'feed', targetEntity: Event::class)]
+    #[ORM\OneToMany(targetEntity: Event::class, mappedBy: 'feed')]
     private Collection $events;
 
     #[ORM\ManyToOne(inversedBy: 'feeds')]
@@ -53,7 +53,7 @@ class Feed
     /**
      * @var Collection<int, FeedItem>
      */
-    #[ORM\OneToMany(mappedBy: 'feed', targetEntity: FeedItem::class, orphanRemoval: true)]
+    #[ORM\OneToMany(targetEntity: FeedItem::class, mappedBy: 'feed', orphanRemoval: true)]
     private Collection $feedItems;
 
     #[ORM\Column(nullable: true)]
@@ -129,10 +129,8 @@ class Feed
     #[Assert\Callback]
     public function validate(ExecutionContextInterface $context, mixed $payload): void
     {
-        if (null !== $this->tmpConfig) {
-            if (false === \json_validate($this->tmpConfig)) {
-                $context->buildViolation('Json error: '.\json_last_error_msg())->atPath('configuration')->addViolation();
-            }
+        if (null !== $this->tmpConfig && false === \json_validate($this->tmpConfig)) {
+            $context->buildViolation('Json error: '.\json_last_error_msg())->atPath('configuration')->addViolation();
         }
     }
 
@@ -205,11 +203,9 @@ class Feed
 
     public function removeEvent(Event $event): static
     {
-        if ($this->events->removeElement($event)) {
-            // set the owning side to null (unless already changed)
-            if ($event->getFeed() === $this) {
-                $event->setFeed(null);
-            }
+        // set the owning side to null (unless already changed)
+        if ($this->events->removeElement($event) && $event->getFeed() === $this) {
+            $event->setFeed(null);
         }
 
         return $this;
@@ -247,11 +243,9 @@ class Feed
 
     public function removeFeedItem(FeedItem $feedItem): static
     {
-        if ($this->feedItems->removeElement($feedItem)) {
-            // set the owning side to null (unless already changed)
-            if ($feedItem->getFeed() === $this) {
-                $feedItem->setFeed(null);
-            }
+        // set the owning side to null (unless already changed)
+        if ($this->feedItems->removeElement($feedItem) && $feedItem->getFeed() === $this) {
+            $feedItem->setFeed(null);
         }
 
         return $this;

--- a/src/Entity/FeedItem.php
+++ b/src/Entity/FeedItem.php
@@ -21,15 +21,8 @@ class FeedItem
     #[ORM\Column]
     private ?int $id = null;
 
-    #[ORM\ManyToOne(cascade: ['persist'], inversedBy: 'feedItems')]
-    #[ORM\JoinColumn(nullable: false)]
-    private ?Feed $feed = null;
-
     #[ORM\OneToOne(inversedBy: 'feedItem', cascade: ['persist', 'remove'])]
     private ?Event $event = null;
-
-    #[ORM\Column(length: 255, nullable: true)]
-    private ?string $feedItemId = null;
 
     #[ORM\Column]
     private array $data = [];
@@ -51,10 +44,11 @@ class FeedItem
     #[ORM\Column]
     private ?\DateTimeImmutable $lastSeenAt = null;
 
-    public function __construct(Feed $feed, string $feedItemId, array $data)
+    public function __construct(#[ORM\ManyToOne(cascade: ['persist'], inversedBy: 'feedItems')]
+        #[ORM\JoinColumn(nullable: false)]
+        private ?Feed $feed, #[ORM\Column(length: 255, nullable: true)]
+        private ?string $feedItemId, array $data)
     {
-        $this->feed = $feed;
-        $this->feedItemId = $feedItemId;
         $this->setData($data);
     }
 
@@ -135,7 +129,7 @@ class FeedItem
 
     public function setLastSeenAt(): static
     {
-        $this->lastSeenAt = new \DateTimeImmutable();
+        $this->lastSeenAt = \Carbon\CarbonImmutable::now();
 
         return $this;
     }

--- a/src/Entity/Image.php
+++ b/src/Entity/Image.php
@@ -13,7 +13,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\SerializedPath;
 
 #[ORM\Entity(repositoryClass: ImageRepository::class)]
-class Image implements EditableEntityInterface
+class Image implements EditableEntityInterface, \Stringable
 {
     use TimestampableEntity;
     use SoftDeleteableEntity;

--- a/src/Entity/Location.php
+++ b/src/Entity/Location.php
@@ -20,7 +20,7 @@ use Symfony\Component\Serializer\Annotation\SerializedPath;
     fields: ['name', 'url', 'mail'],
     message: 'entity.location.unique'
 )]
-class Location implements IndexItemInterface, EditableEntityInterface
+class Location implements IndexItemInterface, EditableEntityInterface, \Stringable
 {
     use TimestampableEntity;
     use SoftDeleteableEntity;
@@ -63,7 +63,7 @@ class Location implements IndexItemInterface, EditableEntityInterface
     #[Groups([IndexNames::Locations->value])]
     private ?Address $address = null;
 
-    #[ORM\OneToMany(mappedBy: 'location', targetEntity: Event::class)]
+    #[ORM\OneToMany(targetEntity: Event::class, mappedBy: 'location')]
     private Collection $events;
 
     public function __construct()
@@ -185,11 +185,9 @@ class Location implements IndexItemInterface, EditableEntityInterface
 
     public function removeEvent(Event $event): static
     {
-        if ($this->events->removeElement($event)) {
-            // set the owning side to null (unless already changed)
-            if ($event->getLocation() === $this) {
-                $event->setLocation(null);
-            }
+        // set the owning side to null (unless already changed)
+        if ($this->events->removeElement($event) && $event->getLocation() === $this) {
+            $event->setLocation(null);
         }
 
         return $this;

--- a/src/Entity/Occurrence.php
+++ b/src/Entity/Occurrence.php
@@ -16,7 +16,7 @@ use Symfony\Component\Serializer\Annotation\SerializedPath;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: OccurrenceRepository::class)]
-class Occurrence implements IndexItemInterface, EditableEntityInterface
+class Occurrence implements IndexItemInterface, EditableEntityInterface, \Stringable
 {
     use TimestampableEntity;
     use SoftDeleteableEntity;
@@ -55,7 +55,7 @@ class Occurrence implements IndexItemInterface, EditableEntityInterface
     #[Groups([IndexNames::Occurrences->value])]
     private ?Event $event = null;
 
-    #[ORM\OneToMany(mappedBy: 'occurrence', targetEntity: DailyOccurrence::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
+    #[ORM\OneToMany(targetEntity: DailyOccurrence::class, mappedBy: 'occurrence', cascade: ['persist', 'remove'], orphanRemoval: true)]
     private Collection $dailyOccurrences;
 
     #[ORM\Column(length: 255, nullable: true)]
@@ -171,11 +171,9 @@ class Occurrence implements IndexItemInterface, EditableEntityInterface
 
     public function removeDailyOccurrence(DailyOccurrence $dailyOccurrence): static
     {
-        if ($this->dailyOccurrences->removeElement($dailyOccurrence)) {
-            // set the owning side to null (unless already changed)
-            if ($dailyOccurrence->getOccurrence() === $this) {
-                $dailyOccurrence->setOccurrence(null);
-            }
+        // set the owning side to null (unless already changed)
+        if ($this->dailyOccurrences->removeElement($dailyOccurrence) && $dailyOccurrence->getOccurrence() === $this) {
+            $dailyOccurrence->setOccurrence(null);
         }
 
         return $this;

--- a/src/Entity/Organization.php
+++ b/src/Entity/Organization.php
@@ -21,7 +21,7 @@ use Symfony\Component\Serializer\Annotation\SerializedPath;
 #[UniqueEntity(
     fields: ['name'],
     message: 'entity.organization.name.not_unique')]
-class Organization implements IndexItemInterface
+class Organization implements IndexItemInterface, \Stringable
 {
     use TimestampableEntity;
     use SoftDeleteableEntity;
@@ -49,10 +49,10 @@ class Organization implements IndexItemInterface
     #[ORM\ManyToMany(targetEntity: User::class, inversedBy: 'organizations')]
     private Collection $users;
 
-    #[ORM\OneToMany(mappedBy: 'organization', targetEntity: Event::class)]
+    #[ORM\OneToMany(targetEntity: Event::class, mappedBy: 'organization')]
     private Collection $events;
 
-    #[ORM\OneToMany(mappedBy: 'organization', targetEntity: Feed::class)]
+    #[ORM\OneToMany(targetEntity: Feed::class, mappedBy: 'organization')]
     private Collection $feeds;
 
     #[Timestampable(on: 'create')]
@@ -168,11 +168,9 @@ class Organization implements IndexItemInterface
 
     public function removeEvent(Event $event): static
     {
-        if ($this->events->removeElement($event)) {
-            // set the owning side to null (unless already changed)
-            if ($event->getOrganization() === $this) {
-                $event->setOrganization(null);
-            }
+        // set the owning side to null (unless already changed)
+        if ($this->events->removeElement($event) && $event->getOrganization() === $this) {
+            $event->setOrganization(null);
         }
 
         return $this;
@@ -198,11 +196,9 @@ class Organization implements IndexItemInterface
 
     public function removeFeed(Feed $feed): static
     {
-        if ($this->feeds->removeElement($feed)) {
-            // set the owning side to null (unless already changed)
-            if ($feed->getOrganization() === $this) {
-                $feed->setOrganization(null);
-            }
+        // set the owning side to null (unless already changed)
+        if ($this->feeds->removeElement($feed) && $feed->getOrganization() === $this) {
+            $feed->setOrganization(null);
         }
 
         return $this;

--- a/src/Entity/Tag.php
+++ b/src/Entity/Tag.php
@@ -18,7 +18,7 @@ use Symfony\Component\Serializer\Attribute as Serializer;
 #[ORM\HasLifecycleCallbacks]
 #[ORM\UniqueConstraint(name: 'tag_name_unique', columns: ['name'])]
 #[ORM\UniqueConstraint(name: 'tag_slug_unique', columns: ['slug'])]
-class Tag implements IndexItemInterface, EditableEntityInterface
+class Tag implements IndexItemInterface, EditableEntityInterface, \Stringable
 {
     use TimestampableEntity;
     use SoftDeleteableEntity;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
     fields: ['mail'],
     message: 'entity.user.mail.not_unique'
 )]
-class User implements UserInterface, PasswordAuthenticatedUserInterface
+class User implements UserInterface, PasswordAuthenticatedUserInterface, \Stringable
 {
     use TimestampableEntity;
     use SoftDeleteableEntity;
@@ -57,7 +57,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\ManyToMany(targetEntity: Organization::class, mappedBy: 'users')]
     private Collection $organizations;
 
-    #[ORM\OneToMany(mappedBy: 'user', targetEntity: Feed::class)]
+    #[ORM\OneToMany(targetEntity: Feed::class, mappedBy: 'user')]
     private Collection $feeds;
 
     #[ORM\Column(nullable: true)]
@@ -182,11 +182,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     public function removeFeed(Feed $feed): static
     {
-        if ($this->feeds->removeElement($feed)) {
-            // set the owning side to null (unless already changed)
-            if ($feed->getUser() === $this) {
-                $feed->setUser(null);
-            }
+        // set the owning side to null (unless already changed)
+        if ($this->feeds->removeElement($feed) && $feed->getUser() === $this) {
+            $feed->setUser(null);
         }
 
         return $this;
@@ -221,7 +219,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
             UserRoles::ROLE_ORGANIZATION_EDITOR->value,
         ];
 
-        if (!empty(array_intersect($this->roles, $organizationRoles)) && $this->organizations->isEmpty()) {
+        if ([] !== array_intersect($this->roles, $organizationRoles) && $this->organizations->isEmpty()) {
             $context
                 ->buildViolation('entity.user.organizations.organization_required')
                 ->atPath('organizations')

--- a/src/Entity/Vocabulary.php
+++ b/src/Entity/Vocabulary.php
@@ -22,7 +22,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 #[UniqueEntity(
     fields: ['slug'],
     message: 'entity.vocabulary.slug.not_unique')]
-class Vocabulary implements IndexItemInterface
+class Vocabulary implements IndexItemInterface, \Stringable
 {
     use TimestampableEntity;
     use SoftDeleteableEntity;

--- a/src/EventSubscriber/EasyAdminSubscriber.php
+++ b/src/EventSubscriber/EasyAdminSubscriber.php
@@ -83,7 +83,7 @@ class EasyAdminSubscriber implements EventSubscriberInterface
             }
 
             $excerpt = $entity->getExcerpt();
-            if (!empty($excerpt)) {
+            if (!in_array($excerpt, [null, '', '0'], true)) {
                 $excerpt = $this->contentNormalizer->trimLength($excerpt, Event::EXCERPT_MAX_LENGTH);
                 $entity->setExcerpt($excerpt);
             } elseif (!is_null($description)) {
@@ -132,7 +132,7 @@ class EasyAdminSubscriber implements EventSubscriberInterface
      */
     private function handleEntity(object $entity): void
     {
-        switch (get_class($entity)) {
+        switch ($entity::class) {
             case Image::class:
             case Tag::class:
             case Address::class:

--- a/src/Exception/AppException.php
+++ b/src/Exception/AppException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Exception;
 
 abstract class AppException extends \Exception

--- a/src/Exception/FactoryException.php
+++ b/src/Exception/FactoryException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Exception;
 
 class FactoryException extends AppException

--- a/src/Exception/FilesystemException.php
+++ b/src/Exception/FilesystemException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Exception;
 
 class FilesystemException extends AppException

--- a/src/Exception/GeocoderException.php
+++ b/src/Exception/GeocoderException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Exception;
 
 class GeocoderException extends \Exception

--- a/src/Exception/ImageFetchException.php
+++ b/src/Exception/ImageFetchException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Exception;
 
 class ImageFetchException extends AppException

--- a/src/Exception/ImageMineTypeException.php
+++ b/src/Exception/ImageMineTypeException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Exception;
 
 class ImageMineTypeException extends AppException

--- a/src/Exception/IndexingException.php
+++ b/src/Exception/IndexingException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Exception;
 
 class IndexingException extends AppException

--- a/src/Exception/NotSupportedEntityException.php
+++ b/src/Exception/NotSupportedEntityException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Exception;
 
 class NotSupportedEntityException extends AppException

--- a/src/Factory/LocationFactory.php
+++ b/src/Factory/LocationFactory.php
@@ -94,8 +94,6 @@ final readonly class LocationFactory
      */
     private function getAddress(FeedItemLocation $location): ?Address
     {
-        $values = [];
-
         // @TODO Figure out if we can lookup by coordinates. Problem 1: precision, Problem 2: We also goecode the street address with DAWA coordinates, overriding the given coordinates.
         // Lookup base on coordinates
         // $latitude = $location->coordinates?->latitude;
@@ -106,14 +104,11 @@ final readonly class LocationFactory
         //        'longitude' => floatval($longitude),
         //    ];
         // }
-
         // Lookup base on city, street (as it may not have been geolocation encoded yet).
-        if (empty($values)) {
-            $values = array_filter([
-                'postalCode' => $location->postalCode,
-                'street' => $location->street,
-            ]);
-        }
+        $values = array_filter([
+            'postalCode' => $location->postalCode,
+            'street' => $location->street,
+        ]);
 
         return $this->addressRepository->findOneBy($values);
     }

--- a/src/Factory/TagsFactory.php
+++ b/src/Factory/TagsFactory.php
@@ -26,11 +26,11 @@ final readonly class TagsFactory
     public function createOrLookup(array $tagNames, ?Vocabulary $vocabulary = null): iterable
     {
         // Normalize to lowercase
-        $tagNames = array_map(fn ($value): string => mb_strtolower($value), $tagNames);
+        $tagNames = array_map(mb_strtolower(...), $tagNames);
         // Ensure we don't have duplicates
         $tagNames = array_flip($tagNames);
 
-        foreach ($tagNames as $tagName => $value) {
+        foreach (array_keys($tagNames) as $tagName) {
             $tag = $this->tagRepository->findOneBy(['slug' => Slugger::slugify($tagName)]);
             if (is_null($tag)) {
                 $tag = new Tag();

--- a/src/Form/AcceptTermsFormType.php
+++ b/src/Form/AcceptTermsFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Form;
 
 use Symfony\Component\Form\AbstractType;
@@ -11,10 +13,6 @@ use Symfony\Component\Validator\Constraints\IsTrue;
 /** @extends AbstractType<mixed> */
 class AcceptTermsFormType extends AbstractType
 {
-    public function __construct()
-    {
-    }
-
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder

--- a/src/Form/RegistrationFormType.php
+++ b/src/Form/RegistrationFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Form;
 
 use App\Entity\User;

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;

--- a/src/Message/AbstractEventIdMessage.php
+++ b/src/Message/AbstractEventIdMessage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Message;
 
 abstract class AbstractEventIdMessage

--- a/src/Message/DailyOccurrenceMessage.php
+++ b/src/Message/DailyOccurrenceMessage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Message;
 
 final class DailyOccurrenceMessage extends AbstractEventIdMessage

--- a/src/Message/EventMessage.php
+++ b/src/Message/EventMessage.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Message;
 
 use App\Model\Feed\FeedItemData;
 
-final class EventMessage
+final readonly class EventMessage
 {
     public function __construct(
-        private readonly FeedItemData $item,
+        private FeedItemData $item,
     ) {
     }
 

--- a/src/Message/FeedItemDataMessage.php
+++ b/src/Message/FeedItemDataMessage.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Message;
 
 use App\Model\Feed\FeedConfiguration;
 
-final class FeedItemDataMessage
+final readonly class FeedItemDataMessage
 {
     public function __construct(
-        private readonly int $feedId,
-        private readonly FeedConfiguration $configuration,
-        private readonly array $data,
-        private readonly bool $forceUpdate = false,
+        private int $feedId,
+        private FeedConfiguration $configuration,
+        private array $data,
+        private bool $forceUpdate = false,
     ) {
     }
 

--- a/src/Message/FeedItemNormalizationMessage.php
+++ b/src/Message/FeedItemNormalizationMessage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Message;
 
 use App\Model\Feed\FeedConfiguration;

--- a/src/Message/GeocoderMessage.php
+++ b/src/Message/GeocoderMessage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Message;
 
 final class GeocoderMessage extends AbstractEventIdMessage

--- a/src/Message/ImageMessage.php
+++ b/src/Message/ImageMessage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Message;
 
 final class ImageMessage extends AbstractEventIdMessage

--- a/src/Message/IndexMessage.php
+++ b/src/Message/IndexMessage.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Message;
 
 use App\Model\Indexing\IndexNames;
 
-final class IndexMessage
+final readonly class IndexMessage
 {
     public function __construct(
-        private readonly int $entityId,
-        private readonly IndexNames $index,
+        private int $entityId,
+        private IndexNames $index,
     ) {
     }
 

--- a/src/Message/ReadFeedMessage.php
+++ b/src/Message/ReadFeedMessage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Message;
 
 use App\Service\Feeds\Reader\FeedReaderInterface;

--- a/src/MessageHandler/EventHandler.php
+++ b/src/MessageHandler/EventHandler.php
@@ -56,7 +56,7 @@ final readonly class EventHandler
 
             $this->entityManager->flush();
 
-            throw new UnrecoverableMessageHandlingException($e->getMessage());
+            throw new UnrecoverableMessageHandlingException($e->getMessage(), $e->getCode(), $e);
         }
     }
 }

--- a/src/MessageHandler/FeedItemNormalizationHandler.php
+++ b/src/MessageHandler/FeedItemNormalizationHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\MessageHandler;
 
 use App\Entity\Event;
@@ -29,17 +31,17 @@ final readonly class FeedItemNormalizationHandler
         // Tags normalization.
         $feedItemData->tags = $this->tagsNormalizer->normalize($feedItemData->tags);
 
-        $feedItemData->url = $feedItemData->url ?? '';
+        $feedItemData->url ??= '';
 
         // Content normalizations check up. HTML fixer etc.
         $feedItemData->description = $this->contentNormalizer->sanitize($feedItemData->description ?? '');
 
         // Set excerpt from description if empty
-        if (empty($feedItemData->excerpt) && !empty($feedItemData->description)) {
+        if (in_array($feedItemData->excerpt, [null, '', '0'], true) && ('' !== $feedItemData->description && '0' !== $feedItemData->description)) {
             $feedItemData->excerpt = $feedItemData->description;
         }
 
-        if (!empty($feedItemData->excerpt)) {
+        if (!in_array($feedItemData->excerpt, [null, '', '0'], true)) {
             try {
                 $feedItemData->excerpt = $this->contentNormalizer->sanitize($feedItemData->excerpt);
                 $feedItemData->excerpt = $this->contentNormalizer->getTextFromHtml($feedItemData->excerpt);

--- a/src/MessageHandler/GeocoderHandler.php
+++ b/src/MessageHandler/GeocoderHandler.php
@@ -35,7 +35,7 @@ final readonly class GeocoderHandler
                 $address->setLatitude($coordinates[0]);
                 $address->setLongitude($coordinates[1]);
                 $this->addressRepository->save($address, true);
-            } catch (GeocoderException|InvalidArgumentException $e) {
+            } catch (GeocoderException|InvalidArgumentException) {
                 // It is fine that not all addresses are possible to geo-encode, so we just log the database id for later
                 // debugging.
                 $this->logger->info(sprintf('Unable to geocode address: %d', $address->getId() ?? -1));

--- a/src/MessageHandler/ImageHandler.php
+++ b/src/MessageHandler/ImageHandler.php
@@ -41,7 +41,7 @@ final readonly class ImageHandler
                     $this->imageRepository->save($image, true);
 
                     $this->imageService->transform($image);
-                } catch (\Exception $e) {
+                } catch (\Exception) {
                     // Indexing should continue even if we cannot fetch the image
                     $this->logger->info(sprintf('Unable to fetch remote image: %d', $source));
                 }

--- a/src/Model/DateTimeInterval.php
+++ b/src/Model/DateTimeInterval.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model;
 
 final class DateTimeInterval

--- a/src/Model/Feed/FeedConfiguration.php
+++ b/src/Model/Feed/FeedConfiguration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Feed;
 
 final readonly class FeedConfiguration
@@ -23,7 +25,7 @@ final readonly class FeedConfiguration
 
     public function supportsPagination(): bool
     {
-        return !(null === $this->pagination) && $this->pagination->supportsPagination();
+        return null !== $this->pagination && $this->pagination->supportsPagination();
     }
 
     public static function getConfigurationTemplate(): array

--- a/src/Model/Feed/FeedItemCoordinates.php
+++ b/src/Model/Feed/FeedItemCoordinates.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Feed;
 
 final class FeedItemCoordinates

--- a/src/Model/Feed/FeedItemData.php
+++ b/src/Model/Feed/FeedItemData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Feed;
 
 final class FeedItemData

--- a/src/Model/Feed/FeedItemLocation.php
+++ b/src/Model/Feed/FeedItemLocation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Feed;
 
 final class FeedItemLocation

--- a/src/Model/Feed/FeedItemOccurrence.php
+++ b/src/Model/Feed/FeedItemOccurrence.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Feed;
 
 final class FeedItemOccurrence

--- a/src/Model/Feed/FeedItemOrganization.php
+++ b/src/Model/Feed/FeedItemOrganization.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Feed;
 
 final readonly class FeedItemOrganization

--- a/src/Model/Feed/FeedItemTag.php
+++ b/src/Model/Feed/FeedItemTag.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Feed;
 
 class FeedItemTag

--- a/src/Model/Feed/FeedPagination.php
+++ b/src/Model/Feed/FeedPagination.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Feed;
 
 final readonly class FeedPagination

--- a/src/Model/Indexing/Criteria/PopulateCriteriaFactory.php
+++ b/src/Model/Indexing/Criteria/PopulateCriteriaFactory.php
@@ -1,15 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Indexing\Criteria;
 
 use App\Model\Indexing\IndexNames;
 
 class PopulateCriteriaFactory
 {
-    public function __construct(
-    ) {
-    }
-
     public function getPopulateCriteria(string $name): array
     {
         $index = IndexNames::from($name);

--- a/src/Model/Indexing/IndexFieldTypes.php
+++ b/src/Model/Indexing/IndexFieldTypes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Indexing;
 
 final class IndexFieldTypes

--- a/src/Model/Indexing/IndexNames.php
+++ b/src/Model/Indexing/IndexNames.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Indexing;
 
 enum IndexNames: string

--- a/src/Model/Indexing/Mappings/Event.php
+++ b/src/Model/Indexing/Mappings/Event.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Indexing\Mappings;
 
 use App\Model\Indexing\IndexFieldTypes;

--- a/src/Model/Indexing/Mappings/EventWithOccurrences.php
+++ b/src/Model/Indexing/Mappings/EventWithOccurrences.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Indexing\Mappings;
 
 class EventWithOccurrences implements MappingsInterface

--- a/src/Model/Indexing/Mappings/Location.php
+++ b/src/Model/Indexing/Mappings/Location.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Indexing\Mappings;
 
 class Location implements MappingsInterface

--- a/src/Model/Indexing/Mappings/MappingsInterface.php
+++ b/src/Model/Indexing/Mappings/MappingsInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Indexing\Mappings;
 
 interface MappingsInterface

--- a/src/Model/Indexing/Mappings/MappingsProvider.php
+++ b/src/Model/Indexing/Mappings/MappingsProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Indexing\Mappings;
 
 use App\Model\Indexing\IndexNames;

--- a/src/Model/Indexing/Mappings/Occurrence.php
+++ b/src/Model/Indexing/Mappings/Occurrence.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Indexing\Mappings;
 
 use App\Model\Indexing\IndexFieldTypes;

--- a/src/Model/Indexing/Mappings/OccurrenceWithEvent.php
+++ b/src/Model/Indexing/Mappings/OccurrenceWithEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Indexing\Mappings;
 
 class OccurrenceWithEvent implements MappingsInterface

--- a/src/Model/Indexing/Mappings/Organizer.php
+++ b/src/Model/Indexing/Mappings/Organizer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Indexing\Mappings;
 
 use App\Model\Indexing\IndexFieldTypes;

--- a/src/Model/Indexing/Mappings/Tag.php
+++ b/src/Model/Indexing/Mappings/Tag.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Indexing\Mappings;
 
 class Tag implements MappingsInterface

--- a/src/Model/Indexing/Mappings/Vocabularies.php
+++ b/src/Model/Indexing/Mappings/Vocabularies.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model\Indexing\Mappings;
 
 class Vocabularies implements MappingsInterface

--- a/src/Repository/AddressRepository.php
+++ b/src/Repository/AddressRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use App\Entity\Address;

--- a/src/Repository/FeedItemRepository.php
+++ b/src/Repository/FeedItemRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use App\Entity\Feed;

--- a/src/Repository/FeedRepository.php
+++ b/src/Repository/FeedRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use App\Entity\Feed;

--- a/src/Repository/ImageRepository.php
+++ b/src/Repository/ImageRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use App\Entity\Image;

--- a/src/Repository/PopulateInterface.php
+++ b/src/Repository/PopulateInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use Doctrine\Common\Collections\Criteria;

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use App\Entity\User;

--- a/src/Security/EmailVerifier.php
+++ b/src/Security/EmailVerifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Security;
 
 use Doctrine\ORM\EntityManagerInterface;
@@ -44,7 +46,7 @@ readonly class EmailVerifier
     {
         $this->verifyEmailHelper->validateEmailConfirmation($request->getUri(), (string) $user->getId(), $user->getMail());
 
-        $user->setEmailVerifiedAt(new \DateTimeImmutable());
+        $user->setEmailVerifiedAt(\Carbon\CarbonImmutable::now());
 
         $this->entityManager->persist($user);
         $this->entityManager->flush();

--- a/src/Security/EventListener/AuthenticationSuccessListener.php
+++ b/src/Security/EventListener/AuthenticationSuccessListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Security\EventListener;
 
 use App\Entity\User;

--- a/src/Security/EventListener/LoginSuccessListener.php
+++ b/src/Security/EventListener/LoginSuccessListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Security\EventListener;
 
 use App\Entity\User;
@@ -11,11 +13,11 @@ use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
 
-final class LoginSuccessListener
+final readonly class LoginSuccessListener
 {
     public function __construct(
-        private readonly UrlGeneratorInterface $router,
-        private readonly Security $security,
+        private UrlGeneratorInterface $router,
+        private Security $security,
     ) {
     }
 

--- a/src/Security/UserInterface.php
+++ b/src/Security/UserInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Security;
 
 interface UserInterface extends \Symfony\Component\Security\Core\User\UserInterface

--- a/src/Security/Voter/AddressVoter.php
+++ b/src/Security/Voter/AddressVoter.php
@@ -31,7 +31,7 @@ final class AddressVoter extends Voter
         return Address::class === $fqcn;
     }
 
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?\Symfony\Component\Security\Core\Authorization\Voter\Vote $vote = null): bool
     {
         $user = $token->getUser();
         assert($user instanceof User);
@@ -52,11 +52,9 @@ final class AddressVoter extends Voter
         $address = $subject['entity']->getInstance();
         assert($address instanceof Address);
 
-        if (Action::SAVE_AND_ADD_ANOTHER === $action || Action::SAVE_AND_CONTINUE === $action || Action::SAVE_AND_RETURN === $action) {
-            // Allow address creation
-            if ($this->security->isGranted(UserRoles::ROLE_ORGANIZATION_ADMIN->value)) {
-                return true;
-            }
+        // Allow address creation
+        if ((Action::SAVE_AND_ADD_ANOTHER === $action || Action::SAVE_AND_CONTINUE === $action || Action::SAVE_AND_RETURN === $action) && $this->security->isGranted(UserRoles::ROLE_ORGANIZATION_ADMIN->value)) {
+            return true;
         }
 
         // Delete is only allowed for editors, and only for unused addresses
@@ -69,10 +67,6 @@ final class AddressVoter extends Voter
         }
 
         // Global Admin/Editor users can edit all addresses
-        if ($this->security->isGranted(UserRoles::ROLE_EDITOR->value)) {
-            return true;
-        }
-
-        return false;
+        return $this->security->isGranted(UserRoles::ROLE_EDITOR->value);
     }
 }

--- a/src/Security/Voter/EventVoter.php
+++ b/src/Security/Voter/EventVoter.php
@@ -31,7 +31,7 @@ final class EventVoter extends Voter
         return Event::class === $fqcn;
     }
 
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?\Symfony\Component\Security\Core\Authorization\Voter\Vote $vote = null): bool
     {
         $user = $token->getUser();
         assert($user instanceof User);

--- a/src/Security/Voter/LocationVoter.php
+++ b/src/Security/Voter/LocationVoter.php
@@ -31,7 +31,7 @@ final class LocationVoter extends Voter
         return Location::class === $fqcn;
     }
 
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?\Symfony\Component\Security\Core\Authorization\Voter\Vote $vote = null): bool
     {
         $user = $token->getUser();
         assert($user instanceof User);
@@ -52,11 +52,9 @@ final class LocationVoter extends Voter
         $location = $subject['entity']->getInstance();
         assert($location instanceof Location);
 
-        if (Action::SAVE_AND_ADD_ANOTHER === $action || Action::SAVE_AND_CONTINUE === $action || Action::SAVE_AND_RETURN === $action) {
-            // Allow location creation
-            if ($this->security->isGranted(UserRoles::ROLE_ORGANIZATION_ADMIN->value)) {
-                return true;
-            }
+        // Allow location creation
+        if ((Action::SAVE_AND_ADD_ANOTHER === $action || Action::SAVE_AND_CONTINUE === $action || Action::SAVE_AND_RETURN === $action) && $this->security->isGranted(UserRoles::ROLE_ORGANIZATION_ADMIN->value)) {
+            return true;
         }
 
         // Delete is only allowed for editors, and only for unused locations
@@ -69,10 +67,6 @@ final class LocationVoter extends Voter
         }
 
         // Global Admin/Editor users can edit all locations
-        if ($this->security->isGranted(UserRoles::ROLE_EDITOR->value)) {
-            return true;
-        }
-
-        return false;
+        return $this->security->isGranted(UserRoles::ROLE_EDITOR->value);
     }
 }

--- a/src/Security/Voter/OrganizationVoter.php
+++ b/src/Security/Voter/OrganizationVoter.php
@@ -31,7 +31,7 @@ final class OrganizationVoter extends Voter
         return Organization::class === $fqcn;
     }
 
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?\Symfony\Component\Security\Core\Authorization\Voter\Vote $vote = null): bool
     {
         $user = $token->getUser();
         assert($user instanceof User);

--- a/src/Security/Voter/TagVoter.php
+++ b/src/Security/Voter/TagVoter.php
@@ -29,7 +29,7 @@ final class TagVoter extends Voter
         return Tag::class === $fqcn;
     }
 
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?\Symfony\Component\Security\Core\Authorization\Voter\Vote $vote = null): bool
     {
         $action = is_string($subject['action']) ? $subject['action'] : $subject['action']->getName();
 

--- a/src/Security/Voter/UserActionVoter.php
+++ b/src/Security/Voter/UserActionVoter.php
@@ -30,7 +30,7 @@ final class UserActionVoter extends Voter
         return User::class === $fqcn;
     }
 
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?\Symfony\Component\Security\Core\Authorization\Voter\Vote $vote = null): bool
     {
         $loggedInUser = $token->getUser();
         assert($loggedInUser instanceof User);

--- a/src/Security/Voter/UserEntityVoter.php
+++ b/src/Security/Voter/UserEntityVoter.php
@@ -23,7 +23,7 @@ final class UserEntityVoter extends Voter
             && User::class === $subject->getFqcn();
     }
 
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?\Symfony\Component\Security\Core\Authorization\Voter\Vote $vote = null): bool
     {
         $user = $token->getUser();
         // if the user is anonymous, do not grant access

--- a/src/Service/ContentNormalizerInterface.php
+++ b/src/Service/ContentNormalizerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service;
 
 interface ContentNormalizerInterface

--- a/src/Service/Dump.php
+++ b/src/Service/Dump.php
@@ -12,10 +12,10 @@ use Symfony\Component\Filesystem\Filesystem;
 /**
  * Class Dump.
  */
-final class Dump
+final readonly class Dump
 {
     public function __construct(
-        private readonly iterable $indexingServices,
+        private iterable $indexingServices,
     ) {
     }
 

--- a/src/Service/EventFinder.php
+++ b/src/Service/EventFinder.php
@@ -12,7 +12,7 @@ final class EventFinder implements EventFinderInterface
 {
     public function findEvents(object $entity): iterable
     {
-        switch (get_class($entity)) {
+        switch ($entity::class) {
             case Image::class:
                 yield $entity->getEvent();
                 break;
@@ -30,7 +30,7 @@ final class EventFinder implements EventFinderInterface
                 break;
 
             default:
-                throw new NotSupportedEntityException(sprintf('The class "%s" is not supported by the EventFinder service', get_class($entity)));
+                throw new NotSupportedEntityException(sprintf('The class "%s" is not supported by the EventFinder service', $entity::class));
         }
     }
 

--- a/src/Service/EventFinderInterface.php
+++ b/src/Service/EventFinderInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service;
 
 use App\Exception\NotSupportedEntityException;

--- a/src/Service/Feeds/Mapper/FeedConfigurationMapper.php
+++ b/src/Service/Feeds/Mapper/FeedConfigurationMapper.php
@@ -22,7 +22,7 @@ final class FeedConfigurationMapper
     public function getConfigurationFromArray(array $configuration): FeedConfiguration
     {
         try {
-            return (new MapperBuilder())
+            return new MapperBuilder()
                 ->allowPermissiveTypes()
                 ->allowSuperfluousKeys()
                 ->allowScalarValueCasting()

--- a/src/Service/Feeds/Mapper/FeedMapper.php
+++ b/src/Service/Feeds/Mapper/FeedMapper.php
@@ -31,7 +31,7 @@ final readonly class FeedMapper implements FeedMapperInterface
         date_default_timezone_set($configuration->timezone);
 
         try {
-            return (new MapperBuilder())
+            return new MapperBuilder()
                 ->allowSuperfluousKeys()
                 ->allowScalarValueCasting()
                 ->allowNonSequentialList()
@@ -40,7 +40,7 @@ final readonly class FeedMapper implements FeedMapperInterface
                 ->mapper()
                 ->map(
                     FeedItemData::class,
-                    Source::iterable((new FeedItemSource($configuration, $this->defaultsMapperService))->normalize($data))
+                    Source::iterable(new FeedItemSource($configuration, $this->defaultsMapperService)->normalize($data))
                 );
         } catch (MappingError $error) {
             // Get flatten list of all messages through the whole nodes tree

--- a/src/Service/Feeds/Mapper/FeedMapperInterface.php
+++ b/src/Service/Feeds/Mapper/FeedMapperInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service\Feeds\Mapper;
 
 use App\Model\Feed\FeedConfiguration;

--- a/src/Service/Feeds/Mapper/Source/FeedItemSource.php
+++ b/src/Service/Feeds/Mapper/Source/FeedItemSource.php
@@ -14,14 +14,14 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
  *
  * @see https://valinor.cuyz.io/1.5/how-to/transform-input/#custom-source
  */
-final class FeedItemSource
+final readonly class FeedItemSource
 {
     private const string SRC_WILDCARD = '*';
     private const string SRC_SEPARATOR = '.';
 
     public function __construct(
-        private readonly FeedConfiguration $configuration,
-        private readonly FeedDefaultsMapper $defaultsMapperService,
+        private FeedConfiguration $configuration,
+        private FeedDefaultsMapper $defaultsMapperService,
     ) {
     }
 
@@ -40,26 +40,26 @@ final class FeedItemSource
 
         foreach ($this->configuration->mapping as $src => $dest) {
             // Match dest that ends with ".[OPERATOR]". to map to array
-            if (preg_match('/(?P<dest>.*)\.\[(?P<separator>.*)]/', $dest, $matches)) {
+            if (preg_match('/(?P<dest>.*)\.\[(?P<separator>.*)]/', (string) $dest, $matches)) {
                 $separator = $matches['separator'];
                 $value = $this->getValue([...$source], $src);
-                $values = empty($separator) ? [$value] : explode($separator, $value);
+                $values = '' === $separator || '0' === $separator ? [$value] : explode($separator, (string) $value);
                 $this->setValue($output, $matches['dest'], $values);
             }
             // Match src with ".*" array without key
-            elseif (str_ends_with($src, self::SRC_SEPARATOR.self::SRC_WILDCARD)) {
+            elseif (str_ends_with((string) $src, self::SRC_SEPARATOR.self::SRC_WILDCARD)) {
                 $values = $this->getArrayValues([...$source], $src);
                 $this->setValues($output, $dest, $values);
             }
             // Match src with ".*." multi value array mapping.
-            elseif (str_contains($src, self::SRC_SEPARATOR.self::SRC_WILDCARD.self::SRC_SEPARATOR)) {
+            elseif (str_contains((string) $src, self::SRC_SEPARATOR.self::SRC_WILDCARD.self::SRC_SEPARATOR)) {
                 $values = $this->getValues([...$source], $src);
                 $this->setValues($output, $dest, $values);
             }
             // Match dest with ".*." single value into array mapping.
-            elseif (str_contains($dest, self::SRC_SEPARATOR.self::SRC_WILDCARD.self::SRC_SEPARATOR)) {
+            elseif (str_contains((string) $dest, self::SRC_SEPARATOR.self::SRC_WILDCARD.self::SRC_SEPARATOR)) {
                 $value = $this->getValue([...$source], $src);
-                $exploded = explode(self::SRC_SEPARATOR.self::SRC_WILDCARD.self::SRC_SEPARATOR, $dest);
+                $exploded = explode(self::SRC_SEPARATOR.self::SRC_WILDCARD.self::SRC_SEPARATOR, (string) $dest);
                 $key = array_shift($exploded);
                 $key = $this->transformKey($key);
 
@@ -162,7 +162,7 @@ final class FeedItemSource
         $keys = explode(self::SRC_SEPARATOR.self::SRC_WILDCARD.self::SRC_SEPARATOR, $src);
         $key = $this->transformKey(reset($keys));
         $items = $propertyAccessor->getValue($data, $key);
-        $items = $items ?? [];
+        $items ??= [];
 
         // Find nested array key and extra values.
         $key = $this->transformKey(array_pop($keys));

--- a/src/Service/Feeds/Parser/FeedParserInterface.php
+++ b/src/Service/Feeds/Parser/FeedParserInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service\Feeds\Parser;
 
 use App\Entity\Feed;

--- a/src/Service/Feeds/Reader/FeedReader.php
+++ b/src/Service/Feeds/Reader/FeedReader.php
@@ -38,12 +38,10 @@ class FeedReader implements FeedReaderInterface
     public function getEnabledFeeds(int $limit, bool $force = false, array $feedIds = []): array
     {
         if (0 === count($feedIds)) {
-            $feeds = $this->feedRepository->findBy(['enabled' => true]);
-        } else {
-            $feeds = $this->feedRepository->findBy(['id' => $feedIds, 'enabled' => true]);
+            return $this->feedRepository->findBy(['enabled' => true]);
         }
 
-        return $feeds;
+        return $this->feedRepository->findBy(['id' => $feedIds, 'enabled' => true]);
     }
 
     /**
@@ -121,7 +119,7 @@ class FeedReader implements FeedReaderInterface
                 $this->cleanUp($feed, $start);
             }
 
-            $feed->setLastRead(new \DateTimeImmutable());
+            $feed->setLastRead(\Carbon\CarbonImmutable::now());
             $feed->setLastReadCount($index);
             $feed->setMessage(null);
             $this->feedRepository->save($feed, true);

--- a/src/Service/Feeds/Reader/FeedReaderInterface.php
+++ b/src/Service/Feeds/Reader/FeedReaderInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service\Feeds\Reader;
 
 use App\Entity\Feed;

--- a/src/Service/Geocoder.php
+++ b/src/Service/Geocoder.php
@@ -15,11 +15,11 @@ use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class Geocoder implements GeocoderInterface
+final readonly class Geocoder implements GeocoderInterface
 {
     public function __construct(
-        private readonly HttpClientInterface $client,
-        private readonly CacheInterface $geoCache,
+        private HttpClientInterface $client,
+        private CacheInterface $geoCache,
     ) {
     }
 

--- a/src/Service/GeocoderInterface.php
+++ b/src/Service/GeocoderInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service;
 
 use App\Entity\Address;

--- a/src/Service/ImageService.php
+++ b/src/Service/ImageService.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final readonly class ImageService implements ImageServiceInterface
 {
-    private const LOCAL_IMAGE_PREFIX = '/images';
+    private const string LOCAL_IMAGE_PREFIX = '/images';
 
     public function __construct(
         private HttpClientInterface $client,
@@ -220,7 +220,7 @@ final readonly class ImageService implements ImageServiceInterface
         if (!in_array($mimetype, $this->allowedMineTypes, true)) {
             throw new ImageMineTypeException(sprintf('The mine type "%s" is not supported', $mimetype));
         }
-        $ext = (new MimeTypes())->getExtensions($mimetype)[0];
+        $ext = new MimeTypes()->getExtensions($mimetype)[0];
 
         return hash('sha256', $url).'.'.$ext;
     }

--- a/src/Service/ImageServiceInterface.php
+++ b/src/Service/ImageServiceInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service;
 
 use App\Entity\Image;

--- a/src/Service/IndexManager.php
+++ b/src/Service/IndexManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service;
 
 use Elastic\Elasticsearch\Client;
@@ -35,7 +37,7 @@ readonly class IndexManager
         $indicesData = [];
         foreach ($indices as $index) {
             $indexName = $index['index'] ?? 'unknown';
-            $index['aliases'] = !empty($aliasesMap[$indexName]) ? $aliasesMap[$indexName] : [];
+            $index['aliases'] = empty($aliasesMap[$indexName]) ? [] : $aliasesMap[$indexName];
             $indicesData[] = $index;
         }
 

--- a/src/Service/Indexing/AbstractIndexingElastic.php
+++ b/src/Service/Indexing/AbstractIndexingElastic.php
@@ -76,7 +76,7 @@ abstract class AbstractIndexingElastic implements IndexingInterface
     {
         try {
             if (null === $this->newIndexName) {
-                $this->newIndexName = $this::INDEX_ALIAS.'_'.date('Y-m-d-His');
+                $this->newIndexName = $this::INDEX_ALIAS.'_'.\Carbon\Carbon::now()->format('Y-m-d-His');
                 $this->createEsIndex($this->newIndexName);
             }
 
@@ -108,7 +108,7 @@ abstract class AbstractIndexingElastic implements IndexingInterface
             throw new IndexingException('Index already exists');
         }
 
-        $newIndexName = $this::INDEX_ALIAS.'_'.date('Y-m-d-His');
+        $newIndexName = $this::INDEX_ALIAS.'_'.\Carbon\Carbon::now()->format('Y-m-d-His');
         $this->createEsIndex($newIndexName);
         $this->refreshIndex($newIndexName);
 

--- a/src/Service/Indexing/IndexItemInterface.php
+++ b/src/Service/Indexing/IndexItemInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service\Indexing;
 
 interface IndexItemInterface

--- a/src/Service/Indexing/IndexingDailyOccurrences.php
+++ b/src/Service/Indexing/IndexingDailyOccurrences.php
@@ -34,9 +34,9 @@ final class IndexingDailyOccurrences extends AbstractIndexingElastic
         $updatedAt = $this->getUpdatedAt($item);
         $item->setUpdatedAt($updatedAt);
 
-        $contextBuilder = (new ObjectNormalizerContextBuilder())
+        $contextBuilder = new ObjectNormalizerContextBuilder()
             ->withGroups([IndexNames::Occurrences->value]);
-        $contextBuilder = (new DateTimeNormalizerContextBuilder())
+        $contextBuilder = new DateTimeNormalizerContextBuilder()
             ->withContext($contextBuilder)
             ->withTimezone($this->viewTimezone)
             ->withFormat(IndexFieldTypes::DATEFORMAT);

--- a/src/Service/Indexing/IndexingEvents.php
+++ b/src/Service/Indexing/IndexingEvents.php
@@ -36,9 +36,9 @@ final class IndexingEvents extends AbstractIndexingElastic
         $updatedAt = $this->getUpdatedAt($item);
         $item->setUpdatedAt($updatedAt);
 
-        $contextBuilder = (new ObjectNormalizerContextBuilder())
+        $contextBuilder = new ObjectNormalizerContextBuilder()
             ->withGroups([IndexNames::Events->value]);
-        $contextBuilder = (new DateTimeNormalizerContextBuilder())
+        $contextBuilder = new DateTimeNormalizerContextBuilder()
             ->withContext($contextBuilder)
             ->withTimezone($this->viewTimezone)
             ->withFormat(IndexFieldTypes::DATEFORMAT);

--- a/src/Service/Indexing/IndexingInterface.php
+++ b/src/Service/Indexing/IndexingInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service\Indexing;
 
 use App\Exception\IndexingException;

--- a/src/Service/Indexing/IndexingLocations.php
+++ b/src/Service/Indexing/IndexingLocations.php
@@ -25,9 +25,9 @@ final class IndexingLocations extends AbstractIndexingElastic
 
     public function serialize(IndexItemInterface $item): array
     {
-        $contextBuilder = (new ObjectNormalizerContextBuilder())
+        $contextBuilder = new ObjectNormalizerContextBuilder()
             ->withGroups([IndexNames::Locations->value]);
-        $contextBuilder = (new DateTimeNormalizerContextBuilder())
+        $contextBuilder = new DateTimeNormalizerContextBuilder()
             ->withContext($contextBuilder)
             ->withTimezone($this->viewTimezone)
             ->withFormat(IndexFieldTypes::DATEFORMAT);

--- a/src/Service/Indexing/IndexingOccurrences.php
+++ b/src/Service/Indexing/IndexingOccurrences.php
@@ -34,9 +34,9 @@ final class IndexingOccurrences extends AbstractIndexingElastic
         $updatedAt = $this->getUpdatedAt($item);
         $item->setUpdatedAt($updatedAt);
 
-        $contextBuilder = (new ObjectNormalizerContextBuilder())
+        $contextBuilder = new ObjectNormalizerContextBuilder()
             ->withGroups([IndexNames::Occurrences->value]);
-        $contextBuilder = (new DateTimeNormalizerContextBuilder())
+        $contextBuilder = new DateTimeNormalizerContextBuilder()
             ->withContext($contextBuilder)
             ->withTimezone($this->viewTimezone)
             ->withFormat(IndexFieldTypes::DATEFORMAT);

--- a/src/Service/Indexing/IndexingOrganizations.php
+++ b/src/Service/Indexing/IndexingOrganizations.php
@@ -25,9 +25,9 @@ final class IndexingOrganizations extends AbstractIndexingElastic
 
     public function serialize(IndexItemInterface $item): array
     {
-        $contextBuilder = (new ObjectNormalizerContextBuilder())
+        $contextBuilder = new ObjectNormalizerContextBuilder()
             ->withGroups([IndexNames::Organizations->value]);
-        $contextBuilder = (new DateTimeNormalizerContextBuilder())
+        $contextBuilder = new DateTimeNormalizerContextBuilder()
             ->withContext($contextBuilder)
             ->withTimezone($this->viewTimezone)
             ->withFormat(IndexFieldTypes::DATEFORMAT);

--- a/src/Service/Indexing/IndexingTags.php
+++ b/src/Service/Indexing/IndexingTags.php
@@ -25,9 +25,9 @@ final class IndexingTags extends AbstractIndexingElastic
 
     public function serialize(IndexItemInterface $item): array
     {
-        $contextBuilder = (new ObjectNormalizerContextBuilder())
+        $contextBuilder = new ObjectNormalizerContextBuilder()
             ->withGroups([IndexNames::Tags->value]);
-        $contextBuilder = (new DateTimeNormalizerContextBuilder())
+        $contextBuilder = new DateTimeNormalizerContextBuilder()
             ->withContext($contextBuilder)
             ->withTimezone($this->viewTimezone)
             ->withFormat(IndexFieldTypes::DATEFORMAT);

--- a/src/Service/Indexing/IndexingVocabularies.php
+++ b/src/Service/Indexing/IndexingVocabularies.php
@@ -25,9 +25,9 @@ final class IndexingVocabularies extends AbstractIndexingElastic
 
     public function serialize(IndexItemInterface $item): array
     {
-        $contextBuilder = (new ObjectNormalizerContextBuilder())
+        $contextBuilder = new ObjectNormalizerContextBuilder()
             ->withGroups([IndexNames::Vocabularies->value]);
-        $contextBuilder = (new DateTimeNormalizerContextBuilder())
+        $contextBuilder = new DateTimeNormalizerContextBuilder()
             ->withContext($contextBuilder)
             ->withTimezone($this->viewTimezone)
             ->withFormat(IndexFieldTypes::DATEFORMAT);

--- a/src/Service/Populate.php
+++ b/src/Service/Populate.php
@@ -134,11 +134,11 @@ final class Populate
     {
         $this->lock = $this->lockFactory->createLock('app:populate:lock', $this::LOCK_TIMEOUT, false);
 
-        if ($this->lock->acquire() || $force) {
+        if ($this->lock->acquire()) {
             return true;
         }
 
-        return false;
+        return $force;
     }
 
     /**

--- a/src/Service/Slugger.php
+++ b/src/Service/Slugger.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service;
 
 use Symfony\Component\String\Slugger\AsciiSlugger;
@@ -8,6 +10,6 @@ class Slugger
 {
     public static function slugify(?string $name): ?string
     {
-        return null === $name ? null : (new AsciiSlugger())->slug($name)->lower()->toString();
+        return null === $name ? null : new AsciiSlugger()->slug($name)->lower()->toString();
     }
 }

--- a/src/Service/TagsNormalizer.php
+++ b/src/Service/TagsNormalizer.php
@@ -6,11 +6,11 @@ use App\Entity\Tag;
 use App\Repository\TagRepository;
 use Doctrine\ORM\EntityManagerInterface;
 
-final class TagsNormalizer implements TagsNormalizerInterface
+final readonly class TagsNormalizer implements TagsNormalizerInterface
 {
     public function __construct(
-        private readonly EntityManagerInterface $em,
-        private readonly TagRepository $tagRepository,
+        private EntityManagerInterface $em,
+        private TagRepository $tagRepository,
     ) {
     }
 
@@ -25,7 +25,7 @@ final class TagsNormalizer implements TagsNormalizerInterface
      */
     public function normalize(array $names): array
     {
-        if (!empty($names)) {
+        if ([] !== $names) {
             $names = array_filter($names);
             $names = $this->trimLength($names);
             $names = $this->normalizeToDbName($names);
@@ -50,7 +50,7 @@ final class TagsNormalizer implements TagsNormalizerInterface
 
         // Ensure we don't exceed field length in db
         return array_map(
-            static fn (string $tag) => mb_substr(trim($tag), 0, $maxNameLength),
+            static fn (string $tag): string => mb_substr(trim($tag), 0, $maxNameLength),
             $names
         );
     }

--- a/src/Service/TagsNormalizerInterface.php
+++ b/src/Service/TagsNormalizerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service;
 
 interface TagsNormalizerInterface

--- a/src/Service/TimeInterval.php
+++ b/src/Service/TimeInterval.php
@@ -23,7 +23,7 @@ final readonly class TimeInterval implements TimeIntervalInterface
         $start = $this->getDateTimeWithTimeZone($start);
         $end = $this->getDateTimeWithTimeZone($end);
 
-        $periods = (new CarbonPeriodImmutable($start, '1 day', $end))->toArray();
+        $periods = new CarbonPeriodImmutable($start, '1 day', $end)->toArray();
 
         // Invalid start/end. Best we can do is return empty array.
         if (0 === count($periods)) {
@@ -86,7 +86,7 @@ final readonly class TimeInterval implements TimeIntervalInterface
      */
     private function getDiffInSeconds(\DateTimeImmutable $start, \DateTimeImmutable $end): int
     {
-        return intval((new CarbonImmutable($start))->diffAsCarbonInterval(new CarbonImmutable($end))->totalSeconds);
+        return intval(new CarbonImmutable($start)->diffAsCarbonInterval(new CarbonImmutable($end))->totalSeconds);
     }
 
     private function getDateTimeWithTimeZone(\DateTimeInterface $dateTime): \DateTimeImmutable

--- a/src/Service/TimeIntervalInterface.php
+++ b/src/Service/TimeIntervalInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service;
 
 use App\Model\DateTimeInterval;

--- a/src/Types/UserRoles.php
+++ b/src/Types/UserRoles.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Types;
 
 enum UserRoles: string

--- a/src/Utils/Validator.php
+++ b/src/Utils/Validator.php
@@ -26,7 +26,7 @@ final class Validator
 {
     public function validatePassword(?string $plainPassword): string
     {
-        if (empty($plainPassword)) {
+        if (in_array($plainPassword, [null, '', '0'], true)) {
             throw new InvalidArgumentException('The password can not be empty.');
         }
 
@@ -39,7 +39,7 @@ final class Validator
 
     public function validateEmail(?string $email): string
     {
-        if (empty($email)) {
+        if (in_array($email, [null, '', '0'], true)) {
             throw new InvalidArgumentException('The email can not be empty.');
         }
 
@@ -52,7 +52,7 @@ final class Validator
 
     public function validateFullName(?string $fullName): string
     {
-        if (empty($fullName)) {
+        if (in_array($fullName, [null, '', '0'], true)) {
             throw new InvalidArgumentException('The full name can not be empty.');
         }
 

--- a/tests/Fixtures/TestEventFixtures.php
+++ b/tests/Fixtures/TestEventFixtures.php
@@ -13,10 +13,10 @@ use Doctrine\Persistence\ObjectManager;
 
 final class TestEventFixtures extends Fixture implements DependentFixtureInterface
 {
-    public const EVENT_ORG_A_1 = 'test-event-org-a-1';
-    public const EVENT_ORG_A_2 = 'test-event-org-a-2';
-    public const EVENT_ORG_B_1 = 'test-event-org-b-1';
-    public const EVENT_ORPHAN = 'test-event-orphan';
+    public const string EVENT_ORG_A_1 = 'test-event-org-a-1';
+    public const string EVENT_ORG_A_2 = 'test-event-org-a-2';
+    public const string EVENT_ORG_B_1 = 'test-event-org-b-1';
+    public const string EVENT_ORPHAN = 'test-event-orphan';
 
     public function load(ObjectManager $manager): void
     {

--- a/tests/Fixtures/TestUserFixtures.php
+++ b/tests/Fixtures/TestUserFixtures.php
@@ -15,14 +15,14 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 final class TestUserFixtures extends Fixture implements DependentFixtureInterface
 {
-    public const PASSWORD = 'test-password';
+    public const string PASSWORD = 'test-password';
 
-    public const SUPER_ADMIN_EMAIL = 'super-admin@test';
-    public const ADMIN_EMAIL = 'admin@test';
-    public const EDITOR_EMAIL = 'editor@test';
-    public const ORG_ADMIN_A_EMAIL = 'org-admin-a@test';
-    public const ORG_EDITOR_A_EMAIL = 'org-editor-a@test';
-    public const ORG_EDITOR_B_EMAIL = 'org-editor-b@test';
+    public const string SUPER_ADMIN_EMAIL = 'super-admin@test';
+    public const string ADMIN_EMAIL = 'admin@test';
+    public const string EDITOR_EMAIL = 'editor@test';
+    public const string ORG_ADMIN_A_EMAIL = 'org-admin-a@test';
+    public const string ORG_EDITOR_A_EMAIL = 'org-editor-a@test';
+    public const string ORG_EDITOR_B_EMAIL = 'org-editor-b@test';
 
     public function __construct(
         private readonly UserPasswordHasherInterface $passwordHasher,

--- a/tests/Functional/AbstractAdminTestCase.php
+++ b/tests/Functional/AbstractAdminTestCase.php
@@ -82,7 +82,7 @@ abstract class AbstractAdminTestCase extends WebTestCase
         // Append any remaining query parameters (filters, referrer, etc.).
         $filtered = array_filter(
             $extra,
-            static fn ($value) => null !== $value,
+            static fn (bool|float|int|string|null $value): bool => null !== $value,
         );
         if ([] !== $filtered) {
             $separator = str_contains($url, '?') ? '&' : '?';

--- a/tests/Functional/Admin/AdminActionAuthorizationTest.php
+++ b/tests/Functional/Admin/AdminActionAuthorizationTest.php
@@ -36,8 +36,8 @@ final class AdminActionAuthorizationTest extends AbstractAdminTestCase
 
     private function entityManager(): EntityManagerInterface
     {
-        $em = static::getContainer()->get(EntityManagerInterface::class);
-        self::assertInstanceOf(EntityManagerInterface::class, $em);
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        $this->assertInstanceOf(EntityManagerInterface::class, $em);
 
         return $em;
     }
@@ -64,7 +64,7 @@ final class AdminActionAuthorizationTest extends AbstractAdminTestCase
         $this->entityManager()->clear();
 
         $this->loginAs(TestUserFixtures::ADMIN_EMAIL);
-        $this->client->request('GET', $this->adminUrl(FeedCrudController::class, Action::EDIT, ['entityId' => $id]));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(FeedCrudController::class, Action::EDIT, ['entityId' => $id]));
 
         $this->assertResponseStatusCodeSame(403);
     }
@@ -80,7 +80,7 @@ final class AdminActionAuthorizationTest extends AbstractAdminTestCase
         $this->entityManager()->clear();
 
         $this->loginAs(TestUserFixtures::SUPER_ADMIN_EMAIL);
-        $this->client->request('GET', $this->adminUrl(FeedCrudController::class, Action::EDIT, ['entityId' => $id]));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(FeedCrudController::class, Action::EDIT, ['entityId' => $id]));
 
         $this->assertResponseIsSuccessful();
     }
@@ -92,7 +92,7 @@ final class AdminActionAuthorizationTest extends AbstractAdminTestCase
     public function testFeedImportedEventEditIsDenied(): void
     {
         $org = $this->entityManager()->getRepository(Organization::class)->findOneBy([]);
-        self::assertInstanceOf(Organization::class, $org);
+        $this->assertInstanceOf(Organization::class, $org);
 
         $feed = $this->createFeed();
 
@@ -109,7 +109,7 @@ final class AdminActionAuthorizationTest extends AbstractAdminTestCase
         $this->entityManager()->clear();
 
         $this->loginAs(TestUserFixtures::ADMIN_EMAIL);
-        $this->client->request('GET', $this->adminUrl(EventCrudController::class, Action::EDIT, ['entityId' => $id]));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(EventCrudController::class, Action::EDIT, ['entityId' => $id]));
 
         $this->assertResponseStatusCodeSame(403);
     }

--- a/tests/Functional/Admin/CrudRenderMatrixTest.php
+++ b/tests/Functional/Admin/CrudRenderMatrixTest.php
@@ -61,13 +61,13 @@ final class CrudRenderMatrixTest extends AbstractAdminTestCase
 
     private function firstId(string $entityClass): int|string
     {
-        $em = static::getContainer()->get(EntityManagerInterface::class);
-        self::assertInstanceOf(EntityManagerInterface::class, $em);
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        $this->assertInstanceOf(EntityManagerInterface::class, $em);
         $entity = $em->getRepository($entityClass)->findOneBy([]);
-        self::assertNotNull($entity, sprintf('Expected at least one %s from fixtures', $entityClass));
+        $this->assertNotNull($entity, sprintf('Expected at least one %s from fixtures', $entityClass));
 
         $id = $em->getUnitOfWork()->getSingleIdentifierValue($entity);
-        self::assertNotNull($id);
+        $this->assertNotNull($id);
 
         return $id;
     }
@@ -102,7 +102,7 @@ final class CrudRenderMatrixTest extends AbstractAdminTestCase
         $id = $this->firstId($entityClass);
 
         foreach ($actions as $action) {
-            $this->client->request('GET', $this->adminUrl($crudControllerFqcn, $action, ['entityId' => $id]));
+            $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl($crudControllerFqcn, $action, ['entityId' => $id]));
             $this->assertResponseIsSuccessful(sprintf('%s %s should render', $crudControllerFqcn, $action));
         }
     }

--- a/tests/Functional/Admin/CrudSmokeTest.php
+++ b/tests/Functional/Admin/CrudSmokeTest.php
@@ -31,8 +31,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
  */
 final class CrudSmokeTest extends AbstractAdminTestCase
 {
-    private const EXPECT_SUCCESS = 'success';
-    private const EXPECT_DENIED = 'denied';
+    private const string EXPECT_SUCCESS = 'success';
+    private const string EXPECT_DENIED = 'denied';
 
     protected function setUp(): void
     {
@@ -51,7 +51,7 @@ final class CrudSmokeTest extends AbstractAdminTestCase
     public function testRoleMatrix(string $controller, string $action, string $email, string $expected): void
     {
         $this->loginAs($email);
-        $this->client->request('GET', $this->adminUrl($controller, $action));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl($controller, $action));
 
         if (self::EXPECT_SUCCESS === $expected) {
             $this->assertResponseIsSuccessful();

--- a/tests/Functional/Admin/CrudWriteRoundTripTest.php
+++ b/tests/Functional/Admin/CrudWriteRoundTripTest.php
@@ -42,8 +42,8 @@ final class CrudWriteRoundTripTest extends AbstractAdminTestCase
 
     private function entityManager(): EntityManagerInterface
     {
-        $em = static::getContainer()->get(EntityManagerInterface::class);
-        self::assertInstanceOf(EntityManagerInterface::class, $em);
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        $this->assertInstanceOf(EntityManagerInterface::class, $em);
 
         return $em;
     }
@@ -55,7 +55,7 @@ final class CrudWriteRoundTripTest extends AbstractAdminTestCase
     {
         $this->loginAs(TestUserFixtures::ADMIN_EMAIL);
 
-        $crawler = $this->client->request('GET', $this->adminUrl(TagCrudController::class, Action::NEW));
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(TagCrudController::class, Action::NEW));
         $this->assertResponseIsSuccessful();
 
         // The slug field is disabled and auto-generated from the name via a
@@ -69,8 +69,8 @@ final class CrudWriteRoundTripTest extends AbstractAdminTestCase
 
         $this->entityManager()->clear();
         $tag = $this->entityManager()->getRepository(Tag::class)->findOneBy(['name' => 'Characterization Tag']);
-        self::assertInstanceOf(Tag::class, $tag);
-        self::assertNotEmpty($tag->getSlug(), 'The slug must be auto-generated on persist');
+        $this->assertInstanceOf(Tag::class, $tag);
+        $this->assertNotEmpty($tag->getSlug(), 'The slug must be auto-generated on persist');
     }
 
     /**
@@ -89,7 +89,7 @@ final class CrudWriteRoundTripTest extends AbstractAdminTestCase
 
         $this->loginAs(TestUserFixtures::ADMIN_EMAIL);
 
-        $crawler = $this->client->request('GET', $this->adminUrl(TagCrudController::class, Action::EDIT, ['entityId' => $id]));
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(TagCrudController::class, Action::EDIT, ['entityId' => $id]));
         $this->assertResponseIsSuccessful();
 
         $form = $crawler->filter('form[name="Tag"]')->form();
@@ -99,8 +99,8 @@ final class CrudWriteRoundTripTest extends AbstractAdminTestCase
 
         $this->entityManager()->clear();
         $updated = $this->entityManager()->getRepository(Tag::class)->find($id);
-        self::assertInstanceOf(Tag::class, $updated);
-        self::assertSame('After', $updated->getName());
+        $this->assertInstanceOf(Tag::class, $updated);
+        $this->assertSame('After', $updated->getName());
     }
 
     /**
@@ -110,12 +110,12 @@ final class CrudWriteRoundTripTest extends AbstractAdminTestCase
     public function testEditEventTitleViaEditFormStampsUpdatedBy(): void
     {
         $event = $this->entityManager()->getRepository(Event::class)->findOneBy(['title' => 'Org A Event 1']);
-        self::assertInstanceOf(Event::class, $event);
+        $this->assertInstanceOf(Event::class, $event);
         $id = $event->getId();
 
         $this->loginAs(TestUserFixtures::ADMIN_EMAIL);
 
-        $crawler = $this->client->request('GET', $this->adminUrl(EventCrudController::class, Action::EDIT, ['entityId' => $id]));
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(EventCrudController::class, Action::EDIT, ['entityId' => $id]));
         $this->assertResponseIsSuccessful();
 
         $form = $crawler->filter('form[name="Event"]')->form();
@@ -125,9 +125,9 @@ final class CrudWriteRoundTripTest extends AbstractAdminTestCase
 
         $this->entityManager()->clear();
         $updated = $this->entityManager()->getRepository(Event::class)->find($id);
-        self::assertInstanceOf(Event::class, $updated);
-        self::assertSame('Org A Event 1 (edited)', $updated->getTitle());
-        self::assertSame(TestUserFixtures::ADMIN_EMAIL, $updated->getUpdatedBy());
+        $this->assertInstanceOf(Event::class, $updated);
+        $this->assertSame('Org A Event 1 (edited)', $updated->getTitle());
+        $this->assertSame(TestUserFixtures::ADMIN_EMAIL, $updated->getUpdatedBy());
     }
 
     /**
@@ -138,7 +138,7 @@ final class CrudWriteRoundTripTest extends AbstractAdminTestCase
     {
         $em = $this->entityManager();
         $org = $this->entityManager()->getRepository(\App\Entity\Organization::class)->findOneBy([]);
-        self::assertNotNull($org);
+        $this->assertInstanceOf(\App\Entity\Organization::class, $org);
 
         $event = new Event();
         $event->setTitle('Cascade Event')
@@ -159,16 +159,13 @@ final class CrudWriteRoundTripTest extends AbstractAdminTestCase
 
         $eventId = $event->getId();
         $occurrenceId = $occurrence->getId();
-        self::assertNotNull($occurrenceId);
+        $this->assertNotNull($occurrenceId);
 
         $em->remove($event);
         $em->flush();
         $em->clear();
 
-        self::assertNull($em->getRepository(Event::class)->find($eventId));
-        self::assertNull(
-            $em->getRepository(Occurrence::class)->find($occurrenceId),
-            'Deleting an event must remove its occurrences',
-        );
+        $this->assertNotInstanceOf(Event::class, $em->getRepository(Event::class)->find($eventId));
+        $this->assertNotInstanceOf(Occurrence::class, $em->getRepository(Occurrence::class)->find($occurrenceId), 'Deleting an event must remove its occurrences');
     }
 }

--- a/tests/Functional/Admin/DashboardTest.php
+++ b/tests/Functional/Admin/DashboardTest.php
@@ -26,7 +26,7 @@ final class DashboardTest extends AbstractAdminTestCase
     public function testSuperAdminSeesAllMenuSections(): void
     {
         $this->loginAs(TestUserFixtures::SUPER_ADMIN_EMAIL);
-        $this->client->request('GET', '/admin');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/admin');
 
         if ($this->client->getResponse()->isRedirection()) {
             $this->client->followRedirect();
@@ -47,7 +47,7 @@ final class DashboardTest extends AbstractAdminTestCase
     public function testEditorRedirectsToEventCrud(): void
     {
         $this->loginAs(TestUserFixtures::EDITOR_EMAIL);
-        $this->client->request('GET', '/admin');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/admin');
 
         $this->assertResponseRedirects();
         $path = (string) parse_url((string) $this->client->getResponse()->headers->get('Location'), PHP_URL_PATH);
@@ -60,7 +60,7 @@ final class DashboardTest extends AbstractAdminTestCase
     public function testOrgEditorRedirectsToMyEventCrud(): void
     {
         $this->loginAs(TestUserFixtures::ORG_EDITOR_A_EMAIL);
-        $this->client->request('GET', '/admin');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/admin');
 
         $this->assertResponseRedirects();
         $path = (string) parse_url((string) $this->client->getResponse()->headers->get('Location'), PHP_URL_PATH);
@@ -73,7 +73,7 @@ final class DashboardTest extends AbstractAdminTestCase
     public function testOrgEditorDoesNotSeeAdminMenuItems(): void
     {
         $this->loginAs(TestUserFixtures::ORG_EDITOR_A_EMAIL);
-        $this->client->request('GET', '/admin');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/admin');
 
         if ($this->client->getResponse()->isRedirection()) {
             $this->client->followRedirect();

--- a/tests/Functional/Admin/EventCrudTest.php
+++ b/tests/Functional/Admin/EventCrudTest.php
@@ -33,7 +33,7 @@ final class EventCrudTest extends AbstractAdminTestCase
     public function testIndexLoadsForAuthorizedRole(string $email): void
     {
         $this->loginAs($email);
-        $this->client->request('GET', $this->adminUrl(EventCrudController::class));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(EventCrudController::class));
 
         $this->assertResponseIsSuccessful();
     }
@@ -57,7 +57,7 @@ final class EventCrudTest extends AbstractAdminTestCase
         $this->loginAs(TestUserFixtures::EDITOR_EMAIL);
         $event = $this->findEventByTitle('Org A Event 1');
 
-        $this->client->request('GET', $this->adminUrl(EventCrudController::class, Action::DETAIL, ['entityId' => $event->getId()]));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(EventCrudController::class, Action::DETAIL, ['entityId' => $event->getId()]));
 
         $this->assertResponseIsSuccessful();
     }
@@ -68,7 +68,7 @@ final class EventCrudTest extends AbstractAdminTestCase
     public function testEditorCanAccessNewForm(): void
     {
         $this->loginAs(TestUserFixtures::EDITOR_EMAIL);
-        $this->client->request('GET', $this->adminUrl(EventCrudController::class, Action::NEW));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(EventCrudController::class, Action::NEW));
 
         $this->assertResponseIsSuccessful();
     }
@@ -81,7 +81,7 @@ final class EventCrudTest extends AbstractAdminTestCase
         $this->loginAs(TestUserFixtures::ORG_EDITOR_A_EMAIL);
         $event = $this->findEventByTitle('Org B Event 1');
 
-        $this->client->request('GET', $this->adminUrl(EventCrudController::class, Action::EDIT, ['entityId' => $event->getId()]));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(EventCrudController::class, Action::EDIT, ['entityId' => $event->getId()]));
 
         $status = $this->client->getResponse()->getStatusCode();
         $this->assertContains($status, [302, 403], sprintf('Expected 302 or 403, got %d', $status));
@@ -89,7 +89,7 @@ final class EventCrudTest extends AbstractAdminTestCase
 
     private function findEventByTitle(string $title): Event
     {
-        $repository = static::getContainer()->get('doctrine')->getManager()->getRepository(Event::class);
+        $repository = self::getContainer()->get('doctrine')->getManager()->getRepository(Event::class);
         $event = $repository->findOneBy(['title' => $title]);
         $this->assertInstanceOf(Event::class, $event, sprintf('Event "%s" not found', $title));
 

--- a/tests/Functional/Admin/Filter/HasOrganizationFilterTest.php
+++ b/tests/Functional/Admin/Filter/HasOrganizationFilterTest.php
@@ -29,7 +29,7 @@ final class HasOrganizationFilterTest extends AbstractAdminTestCase
     public function testFilterForEventsWithoutOrganization(): void
     {
         $this->loginAs(TestUserFixtures::EDITOR_EMAIL);
-        $this->client->request('GET', $this->adminUrl(EventCrudController::class, 'index', [
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(EventCrudController::class, 'index', [
             'filters[hasOrganization]' => '0',
         ]));
 
@@ -45,7 +45,7 @@ final class HasOrganizationFilterTest extends AbstractAdminTestCase
     public function testFilterForEventsWithOrganization(): void
     {
         $this->loginAs(TestUserFixtures::EDITOR_EMAIL);
-        $this->client->request('GET', $this->adminUrl(EventCrudController::class, 'index', [
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(EventCrudController::class, 'index', [
             'filters[hasOrganization]' => '1',
         ]));
 

--- a/tests/Functional/Admin/Filter/JsonContainsFilterTest.php
+++ b/tests/Functional/Admin/Filter/JsonContainsFilterTest.php
@@ -28,7 +28,7 @@ final class JsonContainsFilterTest extends AbstractAdminTestCase
     public function testFilterByEditorRole(): void
     {
         $this->loginAs(TestUserFixtures::ADMIN_EMAIL);
-        $this->client->request('GET', $this->adminUrl(UserCrudController::class, 'index', [
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(UserCrudController::class, 'index', [
             'filters[roles][comparison]' => '=',
             'filters[roles][value]' => UserRoles::ROLE_EDITOR->value,
         ]));
@@ -45,7 +45,7 @@ final class JsonContainsFilterTest extends AbstractAdminTestCase
     public function testFilterByOrgEditorRole(): void
     {
         $this->loginAs(TestUserFixtures::ADMIN_EMAIL);
-        $this->client->request('GET', $this->adminUrl(UserCrudController::class, 'index', [
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(UserCrudController::class, 'index', [
             'filters[roles][comparison]' => '=',
             'filters[roles][value]' => UserRoles::ROLE_ORGANIZATION_EDITOR->value,
         ]));

--- a/tests/Functional/Admin/Filter/MyEventScopingTest.php
+++ b/tests/Functional/Admin/Filter/MyEventScopingTest.php
@@ -29,7 +29,7 @@ final class MyEventScopingTest extends AbstractAdminTestCase
     public function testOrgEditorOnlySeesOwnOrgEvents(): void
     {
         $this->loginAs(TestUserFixtures::ORG_EDITOR_A_EMAIL);
-        $this->client->request('GET', $this->adminUrl(MyEventCrudController::class));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(MyEventCrudController::class));
 
         $this->assertResponseIsSuccessful();
         $content = (string) $this->client->getResponse()->getContent();
@@ -45,7 +45,7 @@ final class MyEventScopingTest extends AbstractAdminTestCase
     public function testOtherOrgEditorSeesOtherOrgEvents(): void
     {
         $this->loginAs(TestUserFixtures::ORG_EDITOR_B_EMAIL);
-        $this->client->request('GET', $this->adminUrl(MyEventCrudController::class));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(MyEventCrudController::class));
 
         $this->assertResponseIsSuccessful();
         $content = (string) $this->client->getResponse()->getContent();

--- a/tests/Functional/Admin/OrganizationCrudTest.php
+++ b/tests/Functional/Admin/OrganizationCrudTest.php
@@ -29,7 +29,7 @@ final class OrganizationCrudTest extends AbstractAdminTestCase
     public function testIndexLoadsForEditor(): void
     {
         $this->loginAs(TestUserFixtures::EDITOR_EMAIL);
-        $this->client->request('GET', $this->adminUrl(OrganizationCrudController::class));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(OrganizationCrudController::class));
 
         $this->assertResponseIsSuccessful();
     }
@@ -42,7 +42,7 @@ final class OrganizationCrudTest extends AbstractAdminTestCase
         $this->loginAs(TestUserFixtures::EDITOR_EMAIL);
         $org = $this->findOrganizationByName('Aakb');
 
-        $this->client->request('GET', $this->adminUrl(OrganizationCrudController::class, Action::DETAIL, ['entityId' => $org->getId()]));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(OrganizationCrudController::class, Action::DETAIL, ['entityId' => $org->getId()]));
 
         $this->assertResponseIsSuccessful();
     }
@@ -53,7 +53,7 @@ final class OrganizationCrudTest extends AbstractAdminTestCase
     public function testEditorCanAccessNewForm(): void
     {
         $this->loginAs(TestUserFixtures::EDITOR_EMAIL);
-        $this->client->request('GET', $this->adminUrl(OrganizationCrudController::class, Action::NEW));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(OrganizationCrudController::class, Action::NEW));
 
         $this->assertResponseIsSuccessful();
     }
@@ -64,7 +64,7 @@ final class OrganizationCrudTest extends AbstractAdminTestCase
     public function testOrgAdminCannotCreateOrganization(): void
     {
         $this->loginAs(TestUserFixtures::ORG_ADMIN_A_EMAIL);
-        $this->client->request('GET', $this->adminUrl(OrganizationCrudController::class, Action::NEW));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(OrganizationCrudController::class, Action::NEW));
 
         $status = $this->client->getResponse()->getStatusCode();
         $this->assertContains($status, [302, 403], sprintf('Expected 302 or 403 for NEW, got %d', $status));
@@ -78,7 +78,7 @@ final class OrganizationCrudTest extends AbstractAdminTestCase
         $this->loginAs(TestUserFixtures::ORG_ADMIN_A_EMAIL);
         $otherOrg = $this->findOrganizationByName('Dokk1');
 
-        $this->client->request('GET', $this->adminUrl(OrganizationCrudController::class, Action::EDIT, ['entityId' => $otherOrg->getId()]));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(OrganizationCrudController::class, Action::EDIT, ['entityId' => $otherOrg->getId()]));
 
         $status = $this->client->getResponse()->getStatusCode();
         $this->assertContains($status, [302, 403], sprintf('Expected 302 or 403, got %d', $status));
@@ -86,7 +86,7 @@ final class OrganizationCrudTest extends AbstractAdminTestCase
 
     private function findOrganizationByName(string $name): Organization
     {
-        $repository = static::getContainer()->get('doctrine')->getManager()->getRepository(Organization::class);
+        $repository = self::getContainer()->get('doctrine')->getManager()->getRepository(Organization::class);
         $org = $repository->findOneBy(['name' => $name]);
         $this->assertInstanceOf(Organization::class, $org, sprintf('Organization "%s" not found', $name));
 

--- a/tests/Functional/Admin/UserCrudTest.php
+++ b/tests/Functional/Admin/UserCrudTest.php
@@ -28,7 +28,7 @@ final class UserCrudTest extends AbstractAdminTestCase
     public function testAdminCanAccessIndex(): void
     {
         $this->loginAs(TestUserFixtures::ADMIN_EMAIL);
-        $this->client->request('GET', $this->adminUrl(UserCrudController::class));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(UserCrudController::class));
 
         $this->assertResponseIsSuccessful();
     }
@@ -39,7 +39,7 @@ final class UserCrudTest extends AbstractAdminTestCase
     public function testAdminCanCreateNewUser(): void
     {
         $this->loginAs(TestUserFixtures::ADMIN_EMAIL);
-        $this->client->request('GET', $this->adminUrl(UserCrudController::class, Action::NEW));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(UserCrudController::class, Action::NEW));
 
         $this->assertResponseIsSuccessful();
     }
@@ -50,7 +50,7 @@ final class UserCrudTest extends AbstractAdminTestCase
     public function testOrgEditorCannotAccessNewUser(): void
     {
         $this->loginAs(TestUserFixtures::ORG_EDITOR_A_EMAIL);
-        $this->client->request('GET', $this->adminUrl(UserCrudController::class, Action::NEW));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(UserCrudController::class, Action::NEW));
 
         $status = $this->client->getResponse()->getStatusCode();
         $this->assertContains($status, [302, 403], sprintf('Expected 302 or 403, got %d', $status));
@@ -64,7 +64,7 @@ final class UserCrudTest extends AbstractAdminTestCase
         $this->loginAs(TestUserFixtures::ORG_EDITOR_A_EMAIL);
         $self = $this->findUser(TestUserFixtures::ORG_EDITOR_A_EMAIL);
 
-        $this->client->request('GET', $this->adminUrl(UserCrudController::class, Action::EDIT, ['entityId' => $self->getId()]));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->adminUrl(UserCrudController::class, Action::EDIT, ['entityId' => $self->getId()]));
 
         $this->assertResponseIsSuccessful();
     }

--- a/tests/Functional/Auth/LoginGateTest.php
+++ b/tests/Functional/Auth/LoginGateTest.php
@@ -37,15 +37,15 @@ final class LoginGateTest extends AbstractAdminTestCase
 
     private function entityManager(): EntityManagerInterface
     {
-        $em = static::getContainer()->get(EntityManagerInterface::class);
-        self::assertInstanceOf(EntityManagerInterface::class, $em);
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        $this->assertInstanceOf(EntityManagerInterface::class, $em);
 
         return $em;
     }
 
     private function submitLogin(string $email, string $password = TestUserFixtures::PASSWORD): void
     {
-        $crawler = $this->client->request('GET', '/admin/login');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/admin/login');
         $form = $crawler->filter('form')->form();
 
         $this->client->submit($form, [
@@ -64,10 +64,7 @@ final class LoginGateTest extends AbstractAdminTestCase
         $this->submitLogin(TestUserFixtures::EDITOR_EMAIL);
 
         $this->assertResponseRedirects();
-        self::assertStringContainsString(
-            '/admin/accept-terms',
-            (string) $this->client->getResponse()->headers->get('Location'),
-        );
+        $this->assertStringContainsString('/admin/accept-terms', (string) $this->client->getResponse()->headers->get('Location'));
     }
 
     /**
@@ -84,13 +81,13 @@ final class LoginGateTest extends AbstractAdminTestCase
         ]);
 
         $this->assertResponseRedirects();
-        self::assertStringContainsString('/admin', (string) $this->client->getResponse()->headers->get('Location'));
-        self::assertStringNotContainsString('/accept-terms', (string) $this->client->getResponse()->headers->get('Location'));
+        $this->assertStringContainsString('/admin', (string) $this->client->getResponse()->headers->get('Location'));
+        $this->assertStringNotContainsString('/accept-terms', (string) $this->client->getResponse()->headers->get('Location'));
 
         $this->entityManager()->clear();
-        $editor = static::getContainer()->get(UserRepository::class)->findOneBy(['mail' => TestUserFixtures::EDITOR_EMAIL]);
-        self::assertInstanceOf(User::class, $editor);
-        self::assertNotNull($editor->getTermsAcceptedAt(), 'Accepting the terms must persist termsAcceptedAt');
+        $editor = self::getContainer()->get(UserRepository::class)->findOneBy(['mail' => TestUserFixtures::EDITOR_EMAIL]);
+        $this->assertInstanceOf(User::class, $editor);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $editor->getTermsAcceptedAt(), 'Accepting the terms must persist termsAcceptedAt');
     }
 
     /**
@@ -99,15 +96,15 @@ final class LoginGateTest extends AbstractAdminTestCase
     public function testUserWithAcceptedTermsIsNotGated(): void
     {
         $em = $this->entityManager();
-        $editor = static::getContainer()->get(UserRepository::class)->findOneBy(['mail' => TestUserFixtures::EDITOR_EMAIL]);
-        self::assertInstanceOf(User::class, $editor);
+        $editor = self::getContainer()->get(UserRepository::class)->findOneBy(['mail' => TestUserFixtures::EDITOR_EMAIL]);
+        $this->assertInstanceOf(User::class, $editor);
         $editor->setTermsAcceptedAt(new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
         $em->flush();
 
         $this->submitLogin(TestUserFixtures::EDITOR_EMAIL);
 
         $this->assertResponseRedirects();
-        self::assertStringNotContainsString('/accept-terms', (string) $this->client->getResponse()->headers->get('Location'));
+        $this->assertStringNotContainsString('/accept-terms', (string) $this->client->getResponse()->headers->get('Location'));
     }
 
     /**
@@ -117,8 +114,8 @@ final class LoginGateTest extends AbstractAdminTestCase
     public function testUnverifiedPlainUserIsBouncedToLogin(): void
     {
         $em = $this->entityManager();
-        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
-        self::assertInstanceOf(UserPasswordHasherInterface::class, $hasher);
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $this->assertInstanceOf(UserPasswordHasherInterface::class, $hasher);
 
         $user = new User();
         $user->setName('Plain User')
@@ -135,6 +132,6 @@ final class LoginGateTest extends AbstractAdminTestCase
         $this->submitLogin('plain-user@test');
 
         $this->assertResponseRedirects();
-        self::assertStringContainsString('/admin/login', (string) $this->client->getResponse()->headers->get('Location'));
+        $this->assertStringContainsString('/admin/login', (string) $this->client->getResponse()->headers->get('Location'));
     }
 }

--- a/tests/Functional/Auth/LoginTest.php
+++ b/tests/Functional/Auth/LoginTest.php
@@ -25,7 +25,7 @@ final class LoginTest extends AbstractAdminTestCase
      */
     public function testValidCredentialsRedirectToAdmin(): void
     {
-        $crawler = $this->client->request('GET', '/admin/login');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/admin/login');
         $form = $crawler->filter('form')->form();
 
         $this->client->submit($form, [
@@ -42,7 +42,7 @@ final class LoginTest extends AbstractAdminTestCase
      */
     public function testInvalidCredentialsShowError(): void
     {
-        $crawler = $this->client->request('GET', '/admin/login');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/admin/login');
         $form = $crawler->filter('form')->form();
 
         $this->client->submit($form, [

--- a/tests/Functional/Auth/RegistrationTest.php
+++ b/tests/Functional/Auth/RegistrationTest.php
@@ -28,7 +28,7 @@ final class RegistrationTest extends AbstractAdminTestCase
      */
     public function testSuccessfulRegistrationPersistsUserAndSendsEmail(): void
     {
-        $crawler = $this->client->request('GET', '/admin/register/');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/admin/register/');
         $form = $crawler->selectButton('Registrer dig')->form();
 
         $email = 'new-user@example.com';
@@ -43,10 +43,10 @@ final class RegistrationTest extends AbstractAdminTestCase
 
         $this->assertResponseIsSuccessful();
 
-        $repository = static::getContainer()->get(UserRepository::class);
+        $repository = self::getContainer()->get(UserRepository::class);
         $user = $repository->findOneBy(['mail' => $email]);
         $this->assertInstanceOf(User::class, $user, 'User should have been persisted during registration');
-        $this->assertNull($user->getEmailVerifiedAt());
+        $this->assertNotInstanceOf(\DateTimeImmutable::class, $user->getEmailVerifiedAt());
 
         // Outbound mail goes through the async Messenger transport in tests,
         // so the message is queued (routed via SendEmailMessage) rather than
@@ -62,7 +62,7 @@ final class RegistrationTest extends AbstractAdminTestCase
      */
     public function testEmailVerificationSetsVerifiedAt(): void
     {
-        $crawler = $this->client->request('GET', '/admin/register/');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/admin/register/');
         $form = $crawler->selectButton('Registrer dig')->form();
 
         $email = 'verify-me@example.com';
@@ -74,11 +74,11 @@ final class RegistrationTest extends AbstractAdminTestCase
             'registration_form[agreeTerms]' => '1',
         ]);
 
-        $repository = static::getContainer()->get(UserRepository::class);
+        $repository = self::getContainer()->get(UserRepository::class);
         $user = $repository->findOneBy(['mail' => $email]);
         $this->assertInstanceOf(User::class, $user);
 
-        $helper = static::getContainer()->get(VerifyEmailHelperInterface::class);
+        $helper = self::getContainer()->get(VerifyEmailHelperInterface::class);
         $signature = $helper->generateSignature(
             'app_verify_email',
             (string) $user->getId(),
@@ -86,14 +86,14 @@ final class RegistrationTest extends AbstractAdminTestCase
             ['id' => $user->getId()],
         );
 
-        $path = parse_url($signature->getSignedUrl(), PHP_URL_PATH).'?'.parse_url($signature->getSignedUrl(), PHP_URL_QUERY);
-        $this->client->request('GET', $path);
+        $path = parse_url((string) $signature->getSignedUrl(), PHP_URL_PATH).'?'.parse_url((string) $signature->getSignedUrl(), PHP_URL_QUERY);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $path);
 
         $this->assertResponseRedirects();
         // Re-fetch rather than refresh: the test container's EM may have
         // been reset between the registration and verification requests.
         $verifiedUser = $repository->findOneBy(['mail' => $email]);
         $this->assertInstanceOf(User::class, $verifiedUser);
-        $this->assertNotNull($verifiedUser->getEmailVerifiedAt());
+        $this->assertInstanceOf(\DateTimeImmutable::class, $verifiedUser->getEmailVerifiedAt());
     }
 }

--- a/tests/Functional/Repository/PopulateRepositoryTest.php
+++ b/tests/Functional/Repository/PopulateRepositoryTest.php
@@ -23,7 +23,7 @@ final class PopulateRepositoryTest extends KernelTestCase
     private function repository(): EventRepository
     {
         $repository = self::getContainer()->get(EventRepository::class);
-        self::assertInstanceOf(EventRepository::class, $repository);
+        $this->assertInstanceOf(EventRepository::class, $repository);
 
         return $repository;
     }
@@ -43,7 +43,7 @@ final class PopulateRepositoryTest extends KernelTestCase
         $this->loadEvents();
 
         // TestEventFixtures creates four events.
-        self::assertSame(4, $this->repository()->countToPopulate([]));
+        $this->assertSame(4, $this->repository()->countToPopulate([]));
     }
 
     public function testFindToPopulateReturnsIdAscending(): void
@@ -55,7 +55,7 @@ final class PopulateRepositoryTest extends KernelTestCase
         $ids = array_map(static fn (Event $e): int => (int) $e->getId(), $events);
         $sorted = $ids;
         sort($sorted);
-        self::assertSame($sorted, $ids, 'findToPopulate must return events ordered by id ascending');
+        $this->assertSame($sorted, $ids, 'findToPopulate must return events ordered by id ascending');
     }
 
     public function testFindToPopulateRespectsLimitAndOffset(): void
@@ -63,15 +63,15 @@ final class PopulateRepositoryTest extends KernelTestCase
         $this->loadEvents();
 
         $all = $this->repository()->findToPopulate([], 100, 0);
-        self::assertGreaterThanOrEqual(4, count($all));
+        $this->assertGreaterThanOrEqual(4, count($all));
 
         $firstTwo = $this->repository()->findToPopulate([], 2, 0);
         $nextTwo = $this->repository()->findToPopulate([], 2, 2);
 
-        self::assertCount(2, $firstTwo);
-        self::assertCount(2, $nextTwo);
+        $this->assertCount(2, $firstTwo);
+        $this->assertCount(2, $nextTwo);
         // Paging is stable and non-overlapping.
-        self::assertSame($all[0]->getId(), $firstTwo[0]->getId());
-        self::assertSame($all[2]->getId(), $nextTwo[0]->getId());
+        $this->assertSame($all[0]->getId(), $firstTwo[0]->getId());
+        $this->assertSame($all[2]->getId(), $nextTwo[0]->getId());
     }
 }

--- a/tests/Functional/Service/Feeds/FeedMapperTest.php
+++ b/tests/Functional/Service/Feeds/FeedMapperTest.php
@@ -19,7 +19,7 @@ final class FeedMapperTest extends KernelTestCase
     private function mapper(): FeedMapperInterface
     {
         $mapper = self::getContainer()->get(FeedMapperInterface::class);
-        self::assertInstanceOf(FeedMapperInterface::class, $mapper);
+        $this->assertInstanceOf(FeedMapperInterface::class, $mapper);
 
         return $mapper;
     }
@@ -60,8 +60,8 @@ final class FeedMapperTest extends KernelTestCase
 
         $item = $this->mapper()->getFeedItemFromArray($data, $this->config());
 
-        self::assertSame('evt-1', $item->id);
-        self::assertSame('100', $item->occurrences[0]->price);
+        $this->assertSame('evt-1', $item->id);
+        $this->assertSame('100', $item->occurrences[0]->price);
     }
 
     /**

--- a/tests/Functional/Service/Feeds/FeedMapperTimezoneTest.php
+++ b/tests/Functional/Service/Feeds/FeedMapperTimezoneTest.php
@@ -39,7 +39,7 @@ final class FeedMapperTimezoneTest extends KernelTestCase
     private function mapper(): FeedMapperInterface
     {
         $mapper = self::getContainer()->get(FeedMapperInterface::class);
-        self::assertInstanceOf(FeedMapperInterface::class, $mapper);
+        $this->assertInstanceOf(FeedMapperInterface::class, $mapper);
 
         return $mapper;
     }
@@ -68,7 +68,7 @@ final class FeedMapperTimezoneTest extends KernelTestCase
     {
         $item = $this->mapper()->getFeedItemFromArray($data, $this->config($dateFormat));
         $start = $item->occurrences[0]->start;
-        self::assertInstanceOf(\DateTimeImmutable::class, $start);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $start);
 
         return $start->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i');
     }
@@ -81,7 +81,7 @@ final class FeedMapperTimezoneTest extends KernelTestCase
     {
         $data = ['id' => 'evt-1', 'occurrences' => [['start' => '2026-08-15T20:45', 'end' => '2026-08-15T21:45']]];
 
-        self::assertSame('2026-08-15 18:45', $this->firstStartAsUtc($data, 'Y-m-d\TH:i'));
+        $this->assertSame('2026-08-15 18:45', $this->firstStartAsUtc($data, 'Y-m-d\TH:i'));
     }
 
     /**
@@ -92,7 +92,7 @@ final class FeedMapperTimezoneTest extends KernelTestCase
     {
         $data = ['id' => 'evt-2', 'occurrences' => [['start' => '2026-03-03T11:00:00', 'end' => '2026-03-03T12:00:00']]];
 
-        self::assertSame('2026-03-03 10:00', $this->firstStartAsUtc($data, 'Y-m-d\TH:i:s'));
+        $this->assertSame('2026-03-03 10:00', $this->firstStartAsUtc($data, 'Y-m-d\TH:i:s'));
     }
 
     /**
@@ -104,6 +104,6 @@ final class FeedMapperTimezoneTest extends KernelTestCase
     {
         $data = ['id' => 'evt-3', 'occurrences' => [['start' => '2026-09-04T19:30:00+02:00', 'end' => '2026-09-04T21:00:00+02:00']]];
 
-        self::assertSame('2026-09-04 17:30', $this->firstStartAsUtc($data, 'Y-m-d\TH:i:sP'));
+        $this->assertSame('2026-09-04 17:30', $this->firstStartAsUtc($data, 'Y-m-d\TH:i:sP'));
     }
 }

--- a/tests/Functional/Service/Indexing/IndexingTimeZoneTest.php
+++ b/tests/Functional/Service/Indexing/IndexingTimeZoneTest.php
@@ -35,7 +35,7 @@ final class IndexingTimeZoneTest extends KernelTestCase
     private function serializer(): SerializerInterface
     {
         $serializer = self::getContainer()->get(SerializerInterface::class);
-        self::assertInstanceOf(SerializerInterface::class, $serializer);
+        $this->assertInstanceOf(SerializerInterface::class, $serializer);
 
         return $serializer;
     }
@@ -44,7 +44,7 @@ final class IndexingTimeZoneTest extends KernelTestCase
     {
         // serialize() never touches the client; a real (unconnected) instance is fine.
         $client = self::getContainer()->get(Client::class);
-        self::assertInstanceOf(Client::class, $client);
+        $this->assertInstanceOf(Client::class, $client);
 
         return $client;
     }
@@ -65,10 +65,10 @@ final class IndexingTimeZoneTest extends KernelTestCase
         $nyUpdated = $newYork->serialize($this->makeOrganization())['updated'];
 
         // 12:00 UTC stays 12:00+00:00; in New York (EDT in July) it is 08:00-04:00.
-        self::assertStringContainsString('2026-07-01T12:00:00', $utcUpdated);
-        self::assertStringEndsWith('+00:00', $utcUpdated);
-        self::assertStringContainsString('2026-07-01T08:00:00', $nyUpdated);
-        self::assertStringEndsWith('-04:00', $nyUpdated);
+        $this->assertStringContainsString('2026-07-01T12:00:00', (string) $utcUpdated);
+        $this->assertStringEndsWith('+00:00', $utcUpdated);
+        $this->assertStringContainsString('2026-07-01T08:00:00', (string) $nyUpdated);
+        $this->assertStringEndsWith('-04:00', $nyUpdated);
     }
 
     /**
@@ -78,13 +78,13 @@ final class IndexingTimeZoneTest extends KernelTestCase
     public function testContainerServiceUsesApplicationViewTimezone(): void
     {
         $indexing = self::getContainer()->get(IndexingOrganizations::class);
-        self::assertInstanceOf(IndexingOrganizations::class, $indexing);
+        $this->assertInstanceOf(IndexingOrganizations::class, $indexing);
 
         $updated = $indexing->serialize($this->makeOrganization())['updated'];
 
         // Europe/Copenhagen in July is CEST (+02:00): 12:00 UTC -> 14:00+02:00.
-        self::assertSame('Europe/Copenhagen', DashboardController::VIEW_TIMEZONE);
-        self::assertStringContainsString('2026-07-01T14:00:00', $updated);
-        self::assertStringEndsWith('+02:00', $updated);
+        $this->assertSame('Europe/Copenhagen', DashboardController::VIEW_TIMEZONE);
+        $this->assertStringContainsString('2026-07-01T14:00:00', (string) $updated);
+        $this->assertStringEndsWith('+02:00', $updated);
     }
 }

--- a/tests/Functional/Smoke/NginxAdminAssetSmokeTest.php
+++ b/tests/Functional/Smoke/NginxAdminAssetSmokeTest.php
@@ -39,16 +39,12 @@ final class NginxAdminAssetSmokeTest extends TestCase
             self::markTestSkipped(sprintf('nginx not reachable at %s (requires the docker stack): %s', $baseUrl, $e->getMessage()));
         }
 
-        self::assertSame(
-            200,
+        $this->assertSame(200, $status, sprintf(
+            'Expected admin-prefixed asset "%s" to be served via the nginx APP_PATH_PREFIX rewrite, got %d. '
+            .'The "rewrite ^${APP_PATH_PREFIX}/(.*) /$1 break;" rule in .docker/templates/default.conf.template is likely missing.',
+            $url,
             $status,
-            sprintf(
-                'Expected admin-prefixed asset "%s" to be served via the nginx APP_PATH_PREFIX rewrite, got %d. '
-                .'The "rewrite ^${APP_PATH_PREFIX}/(.*) /$1 break;" rule in .docker/templates/default.conf.template is likely missing.',
-                $url,
-                $status,
-            ),
-        );
+        ));
     }
 
     /**

--- a/tests/Unit/Doctrine/UTCDateTimeImmutableTypeTest.php
+++ b/tests/Unit/Doctrine/UTCDateTimeImmutableTypeTest.php
@@ -39,7 +39,7 @@ final class UTCDateTimeImmutableTypeTest extends TestCase
 
         $db = $this->type->convertToDatabaseValue($value, $this->platform());
 
-        self::assertSame('2026-07-01 12:00:00', $db);
+        $this->assertSame('2026-07-01 12:00:00', $db);
     }
 
     /**
@@ -52,8 +52,8 @@ final class UTCDateTimeImmutableTypeTest extends TestCase
 
         $this->type->convertToDatabaseValue($value, $this->platform());
 
-        self::assertSame('Europe/Copenhagen', $value->getTimezone()->getName());
-        self::assertSame('2026-07-01 14:00:00', $value->format('Y-m-d H:i:s'));
+        $this->assertSame('Europe/Copenhagen', $value->getTimezone()->getName());
+        $this->assertSame('2026-07-01 14:00:00', $value->format('Y-m-d H:i:s'));
     }
 
     /**
@@ -63,7 +63,7 @@ final class UTCDateTimeImmutableTypeTest extends TestCase
     {
         $value = new \DateTimeImmutable('2026-07-01 12:00:00', new \DateTimeZone('UTC'));
 
-        self::assertSame('2026-07-01 12:00:00', $this->type->convertToDatabaseValue($value, $this->platform()));
+        $this->assertSame('2026-07-01 12:00:00', $this->type->convertToDatabaseValue($value, $this->platform()));
     }
 
     /**
@@ -71,8 +71,8 @@ final class UTCDateTimeImmutableTypeTest extends TestCase
      */
     public function testNullIsPreserved(): void
     {
-        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform()));
-        self::assertNull($this->type->convertToPHPValue(null, $this->platform()));
+        $this->assertNull($this->type->convertToDatabaseValue(null, $this->platform()));
+        $this->assertNull($this->type->convertToPHPValue(null, $this->platform()));
     }
 
     /**
@@ -82,9 +82,9 @@ final class UTCDateTimeImmutableTypeTest extends TestCase
     {
         $value = $this->type->convertToPHPValue('2026-07-01 12:00:00', $this->platform());
 
-        self::assertInstanceOf(\DateTimeImmutable::class, $value);
-        self::assertSame('UTC', $value->getTimezone()->getName());
-        self::assertSame('2026-07-01 12:00:00', $value->format('Y-m-d H:i:s'));
+        $this->assertInstanceOf(\DateTimeImmutable::class, $value);
+        $this->assertSame('UTC', $value->getTimezone()->getName());
+        $this->assertSame('2026-07-01 12:00:00', $value->format('Y-m-d H:i:s'));
     }
 
     /**
@@ -94,6 +94,6 @@ final class UTCDateTimeImmutableTypeTest extends TestCase
     {
         $existing = new \DateTimeImmutable('2026-07-01 12:00:00', new \DateTimeZone('UTC'));
 
-        self::assertSame($existing, $this->type->convertToPHPValue($existing, $this->platform()));
+        $this->assertSame($existing, $this->type->convertToPHPValue($existing, $this->platform()));
     }
 }

--- a/tests/Unit/Doctrine/UTCDateTimeTypeTest.php
+++ b/tests/Unit/Doctrine/UTCDateTimeTypeTest.php
@@ -38,7 +38,7 @@ final class UTCDateTimeTypeTest extends TestCase
 
         $db = $this->type->convertToDatabaseValue($value, $this->platform());
 
-        self::assertSame('2026-07-01 12:00:00', $db);
+        $this->assertSame('2026-07-01 12:00:00', $db);
     }
 
     /**
@@ -51,8 +51,8 @@ final class UTCDateTimeTypeTest extends TestCase
 
         $this->type->convertToDatabaseValue($value, $this->platform());
 
-        self::assertSame('Europe/Copenhagen', $value->getTimezone()->getName());
-        self::assertSame('2026-07-01 14:00:00', $value->format('Y-m-d H:i:s'));
+        $this->assertSame('Europe/Copenhagen', $value->getTimezone()->getName());
+        $this->assertSame('2026-07-01 14:00:00', $value->format('Y-m-d H:i:s'));
     }
 
     /**
@@ -64,8 +64,8 @@ final class UTCDateTimeTypeTest extends TestCase
 
         $db = $this->type->convertToDatabaseValue($value, $this->platform());
 
-        self::assertSame('2026-07-01 12:00:00', $db);
-        self::assertSame('UTC', $value->getTimezone()->getName());
+        $this->assertSame('2026-07-01 12:00:00', $db);
+        $this->assertSame('UTC', $value->getTimezone()->getName());
     }
 
     /**
@@ -73,6 +73,6 @@ final class UTCDateTimeTypeTest extends TestCase
      */
     public function testNullIsPreserved(): void
     {
-        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform()));
+        $this->assertNull($this->type->convertToDatabaseValue(null, $this->platform()));
     }
 }

--- a/tests/Unit/Factory/OccurrencesFactoryTest.php
+++ b/tests/Unit/Factory/OccurrencesFactoryTest.php
@@ -17,17 +17,17 @@ final class OccurrencesFactoryTest extends KernelTestCase
     /**
      * @throws \Exception
      */
-    public function testOccurrenceUpdate()
+    public function testOccurrenceUpdate(): void
     {
         $itemOccurrence = new FeedItemOccurrence();
-        $itemOccurrence->start = new \DateTimeImmutable('2023-01-19T14:00:00+00:00');
-        $itemOccurrence->end = new \DateTimeImmutable('2023-01-19T15:30:00+00:00');
+        $itemOccurrence->start = \Carbon\CarbonImmutable::parse('2023-01-19T14:00:00+00:00');
+        $itemOccurrence->end = \Carbon\CarbonImmutable::parse('2023-01-19T15:30:00+00:00');
         $itemOccurrence->price = '200';
         $input = [$itemOccurrence];
 
         $eventOccurrence = new Occurrence();
-        $eventOccurrence->setStart(new \DateTimeImmutable('2023-01-19T14:00:00+00:00'))
-            ->setEnd(new \DateTimeImmutable('2023-01-19T15:30:00+00:00'))
+        $eventOccurrence->setStart(\Carbon\CarbonImmutable::parse('2023-01-19T14:00:00+00:00'))
+            ->setEnd(\Carbon\CarbonImmutable::parse('2023-01-19T15:30:00+00:00'))
             ->setTicketPriceRange('400');
 
         $event = new Event();
@@ -46,22 +46,22 @@ final class OccurrencesFactoryTest extends KernelTestCase
     /**
      * @throws \Exception
      */
-    public function testOccurrenceAdd()
+    public function testOccurrenceAdd(): void
     {
         $itemOccurrence = new FeedItemOccurrence();
-        $itemOccurrence->start = new \DateTimeImmutable('2023-01-19T14:00:00+00:00');
-        $itemOccurrence->end = new \DateTimeImmutable('2023-01-19T15:30:00+00:00');
+        $itemOccurrence->start = \Carbon\CarbonImmutable::parse('2023-01-19T14:00:00+00:00');
+        $itemOccurrence->end = \Carbon\CarbonImmutable::parse('2023-01-19T15:30:00+00:00');
         $itemOccurrence->price = '200';
 
         $itemOccurrence2 = new FeedItemOccurrence();
-        $itemOccurrence2->start = new \DateTimeImmutable('2023-02-18T10:00:00+00:00');
-        $itemOccurrence2->end = new \DateTimeImmutable('2023-02-18T16:30:00+00:00');
+        $itemOccurrence2->start = \Carbon\CarbonImmutable::parse('2023-02-18T10:00:00+00:00');
+        $itemOccurrence2->end = \Carbon\CarbonImmutable::parse('2023-02-18T16:30:00+00:00');
         $itemOccurrence2->price = '100';
         $input = [$itemOccurrence, $itemOccurrence2];
 
         $eventOccurrence = new Occurrence();
-        $eventOccurrence->setStart(new \DateTimeImmutable('2023-01-19T14:00:00+00:00'))
-            ->setEnd(new \DateTimeImmutable('2023-01-19T15:30:00+00:00'))
+        $eventOccurrence->setStart(\Carbon\CarbonImmutable::parse('2023-01-19T14:00:00+00:00'))
+            ->setEnd(\Carbon\CarbonImmutable::parse('2023-01-19T15:30:00+00:00'))
             ->setTicketPriceRange('200');
 
         $event = new Event();
@@ -81,22 +81,22 @@ final class OccurrencesFactoryTest extends KernelTestCase
     /**
      * @throws \Exception
      */
-    public function testOccurrenceRemove()
+    public function testOccurrenceRemove(): void
     {
         $itemOccurrence = new FeedItemOccurrence();
-        $itemOccurrence->start = new \DateTimeImmutable('2023-01-19T14:00:00+00:00');
-        $itemOccurrence->end = new \DateTimeImmutable('2023-01-19T15:30:00+00:00');
+        $itemOccurrence->start = \Carbon\CarbonImmutable::parse('2023-01-19T14:00:00+00:00');
+        $itemOccurrence->end = \Carbon\CarbonImmutable::parse('2023-01-19T15:30:00+00:00');
         $itemOccurrence->price = '200';
 
         $input = [$itemOccurrence];
 
         $eventOccurrence = new Occurrence();
-        $eventOccurrence->setStart(new \DateTimeImmutable('2023-01-19T14:00:00+00:00'))
-            ->setEnd(new \DateTimeImmutable('2023-01-19T15:30:00+00:00'))
+        $eventOccurrence->setStart(\Carbon\CarbonImmutable::parse('2023-01-19T14:00:00+00:00'))
+            ->setEnd(\Carbon\CarbonImmutable::parse('2023-01-19T15:30:00+00:00'))
             ->setTicketPriceRange('200');
         $eventOccurrence2 = new Occurrence();
-        $eventOccurrence2->setStart(new \DateTimeImmutable('2023-05-20T10:00:00+00:00'))
-            ->setEnd(new \DateTimeImmutable('2023-05-20T11:30:00+00:00'))
+        $eventOccurrence2->setStart(\Carbon\CarbonImmutable::parse('2023-05-20T10:00:00+00:00'))
+            ->setEnd(\Carbon\CarbonImmutable::parse('2023-05-20T11:30:00+00:00'))
             ->setTicketPriceRange('300-400');
 
         $event = new Event();

--- a/tests/Unit/Model/Indexing/Mappings/MappingsProviderTest.php
+++ b/tests/Unit/Model/Indexing/Mappings/MappingsProviderTest.php
@@ -22,7 +22,7 @@ final class MappingsProviderTest extends TestCase
     #[DataProvider('indexProvider')]
     public function testEveryIndexResolvesToNonEmptyProperties(IndexNames $index): void
     {
-        self::assertNotEmpty(MappingsProvider::propertiesFor($index), $index->value.' must map to a non-empty property set');
+        $this->assertNotEmpty(MappingsProvider::propertiesFor($index), $index->value.' must map to a non-empty property set');
     }
 
     #[DataProvider('indexProvider')]
@@ -30,8 +30,8 @@ final class MappingsProviderTest extends TestCase
     {
         $mapping = MappingsProvider::mappingFor($index);
 
-        self::assertSame('strict', $mapping['dynamic'], $index->value.' mapping must be dynamic:strict');
-        self::assertSame(MappingsProvider::propertiesFor($index), $mapping['properties']);
+        $this->assertSame('strict', $mapping['dynamic'], $index->value.' mapping must be dynamic:strict');
+        $this->assertSame(MappingsProvider::propertiesFor($index), $mapping['properties']);
     }
 
     public function testEventMappingCarriesNestedObjects(): void
@@ -39,18 +39,18 @@ final class MappingsProviderTest extends TestCase
         $properties = MappingsProvider::propertiesFor(IndexNames::Events);
 
         // Composite event mapping embeds occurrences and the organizer/location objects.
-        self::assertArrayHasKey('occurrences', $properties);
-        self::assertArrayHasKey('dailyOccurrences', $properties);
-        self::assertArrayHasKey('properties', $properties['organizer']);
-        self::assertArrayHasKey('properties', $properties['location']);
+        $this->assertArrayHasKey('occurrences', $properties);
+        $this->assertArrayHasKey('dailyOccurrences', $properties);
+        $this->assertArrayHasKey('properties', $properties['organizer']);
+        $this->assertArrayHasKey('properties', $properties['location']);
     }
 
     public function testOccurrenceMappingCarriesParentEvent(): void
     {
         $properties = MappingsProvider::propertiesFor(IndexNames::Occurrences);
 
-        self::assertArrayHasKey('event', $properties);
-        self::assertArrayHasKey('properties', $properties['event']);
+        $this->assertArrayHasKey('event', $properties);
+        $this->assertArrayHasKey('properties', $properties['event']);
     }
 
     /**

--- a/tests/Unit/Service/ContentNormalizerTest.php
+++ b/tests/Unit/Service/ContentNormalizerTest.php
@@ -15,18 +15,18 @@ final class ContentNormalizerTest extends KernelTestCase
     /**
      * @throws \Exception
      */
-    public function testNormalization()
+    public function testNormalization(): void
     {
         $service = $this->getContentNormalizerService();
         $normalized = $service->sanitize('<p>test<b>test<p><a href="http://aakb.dk/test.php"></a></p>');
 
-        $this->assertEquals('<p>test<b>test</b></p><p><b><a href="https://aakb.dk/test.php"></a></b></p>', $normalized);
+        $this->assertSame('<p>test<b>test</b></p><p><b><a href="https://aakb.dk/test.php"></a></b></p>', $normalized);
     }
 
     /**
      * @throws \Exception
      */
-    public function testTrimLength()
+    public function testTrimLength(): void
     {
         $service = $this->getContentNormalizerService();
 
@@ -38,7 +38,7 @@ final class ContentNormalizerTest extends KernelTestCase
 
         // Test split without limiting to word boundaries.
         $trimmed = $service->trimLength(TestData::LONG_STRING, 255, false);
-        $this->assertEquals(255, mb_strlen($trimmed));
+        $this->assertSame(255, mb_strlen($trimmed));
         $this->assertStringEndsWith('surv', $trimmed);
         $this->assertStringEndsNotWith(' ', $trimmed);
     }

--- a/tests/Unit/Service/Feeds/Mapper/FeedConfigurationMapperTest.php
+++ b/tests/Unit/Service/Feeds/Mapper/FeedConfigurationMapperTest.php
@@ -34,12 +34,12 @@ final class FeedConfigurationMapperTest extends TestCase
     {
         $config = $this->mapper->getConfigurationFromArray(FeedConfiguration::getConfigurationTemplate());
 
-        self::assertInstanceOf(FeedConfiguration::class, $config);
-        self::assertSame('json', $config->type);
-        self::assertSame('Europe/Copenhagen', $config->timezone);
-        self::assertSame("Y-m-d\TH:i:sP", $config->dateFormat);
-        self::assertArrayHasKey('id', $config->mapping);
-        self::assertNotNull($config->pagination);
+        $this->assertInstanceOf(FeedConfiguration::class, $config);
+        $this->assertSame('json', $config->type);
+        $this->assertSame('Europe/Copenhagen', $config->timezone);
+        $this->assertSame("Y-m-d\TH:i:sP", $config->dateFormat);
+        $this->assertArrayHasKey('id', $config->mapping);
+        $this->assertInstanceOf(\App\Model\Feed\FeedPagination::class, $config->pagination);
     }
 
     /**
@@ -53,7 +53,7 @@ final class FeedConfigurationMapperTest extends TestCase
 
         $config = $this->mapper->getConfigurationFromArray($data);
 
-        self::assertSame('https://example.test/feed', $config->url);
+        $this->assertSame('https://example.test/feed', $config->url);
     }
 
     /**
@@ -73,9 +73,9 @@ final class FeedConfigurationMapperTest extends TestCase
 
         $config = $this->mapper->getConfigurationFromArray($data);
 
-        self::assertNotNull($config->pagination);
-        self::assertSame(3, $config->pagination->page);
-        self::assertSame(25, $config->pagination->limit);
+        $this->assertInstanceOf(\App\Model\Feed\FeedPagination::class, $config->pagination);
+        $this->assertSame(3, $config->pagination->page);
+        $this->assertSame(25, $config->pagination->limit);
     }
 
     /**

--- a/tests/Unit/Service/Feeds/Mapper/Source/FeedItemSourceTest.php
+++ b/tests/Unit/Service/Feeds/Mapper/Source/FeedItemSourceTest.php
@@ -168,7 +168,7 @@ final class FeedItemSourceTest extends KernelTestCase
      *
      * @throws \Exception
      */
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $feedConfig = new FeedConfiguration(
             type: 'json',

--- a/tests/Unit/Service/GeocoderTest.php
+++ b/tests/Unit/Service/GeocoderTest.php
@@ -16,7 +16,7 @@ final class GeocoderTest extends KernelTestCase
     /**
      * @throws \Exception
      */
-    public function testBuildQuery()
+    public function testBuildQuery(): void
     {
         $address = new Address();
         $address->setStreet('Hack Kampmanns Plads 2')

--- a/tests/Unit/Service/ImageHandlerTest.php
+++ b/tests/Unit/Service/ImageHandlerTest.php
@@ -16,7 +16,7 @@ final class ImageHandlerTest extends KernelTestCase
     /**
      * @throws \Exception
      */
-    public function testCreatePath()
+    public function testCreatePath(): void
     {
         $depth = 2;
         $size = 10;
@@ -26,14 +26,14 @@ final class ImageHandlerTest extends KernelTestCase
             ['https://bora-bora.dk/wp-content/uploads/2023/06/DansBabyDans-Web-Main-2600x1500px-scaled.jpg', false, $depth, $size]
         );
 
-        $this->assertEquals($depth * $size + 2, strlen($path));
+        $this->assertSame($depth * $size + 2, strlen((string) $path));
         $this->assertStringEndsWith('/', $path);
     }
 
     /**
      * @throws \Exception
      */
-    public function testGenerateLocalFilename()
+    public function testGenerateLocalFilename(): void
     {
         $filename = PhpUnitUtils::callPrivateMethod(
             $this->getImageService(),
@@ -62,7 +62,7 @@ final class ImageHandlerTest extends KernelTestCase
     /**
      * @throws \Exception
      */
-    public function testMineTypesException()
+    public function testMineTypesException(): void
     {
         $this->expectException(ImageMineTypeException::class);
         PhpUnitUtils::callPrivateMethod(

--- a/tests/Unit/Service/TagsNormalizerTest.php
+++ b/tests/Unit/Service/TagsNormalizerTest.php
@@ -15,7 +15,7 @@ final class TagsNormalizerTest extends KernelTestCase
     /**
      * @throws \Exception
      */
-    public function testTrimLength()
+    public function testTrimLength(): void
     {
         $tagsNames = PhpUnitUtils::callPrivateMethod(
             $this->getTagsNormalizerService(),
@@ -32,7 +32,7 @@ final class TagsNormalizerTest extends KernelTestCase
         $this->assertEquals('laserskæring', $tagsNames[0]);
         $this->assertEquals('lasercut', $tagsNames[1]);
         $this->assertEquals('3D print', $tagsNames[2]);
-        $this->assertEquals(255, strlen($tagsNames[3]));
+        $this->assertSame(255, strlen((string) $tagsNames[3]));
     }
 
     /**

--- a/tests/Unit/Service/TimeIntervalTest.php
+++ b/tests/Unit/Service/TimeIntervalTest.php
@@ -14,12 +14,12 @@ final class TimeIntervalTest extends KernelTestCase
     /**
      * @throws \Exception
      */
-    public function testTimeIntervalSingleDay()
+    public function testTimeIntervalSingleDay(): void
     {
         $time = $this->getTimeService();
 
-        $start = new \DateTimeImmutable('2023-09-23T10:00:00+02:00');
-        $end = new \DateTimeImmutable('2023-09-23T12:30:00+02:00');
+        $start = \Carbon\CarbonImmutable::parse('2023-09-23T10:00:00+02:00');
+        $end = \Carbon\CarbonImmutable::parse('2023-09-23T12:30:00+02:00');
 
         $times = $time->getIntervals($start, $end);
 
@@ -28,12 +28,12 @@ final class TimeIntervalTest extends KernelTestCase
         $this->assertEquals($end, $times[0]->end);
     }
 
-    public function testTimeIntervalSpanMidnight()
+    public function testTimeIntervalSpanMidnight(): void
     {
         $time = $this->getTimeService();
 
-        $start = new \DateTimeImmutable('2023-09-23T10:00:00+02:00');
-        $end = new \DateTimeImmutable('2023-09-23T12:30:00+02:00');
+        $start = \Carbon\CarbonImmutable::parse('2023-09-23T10:00:00+02:00');
+        $end = \Carbon\CarbonImmutable::parse('2023-09-23T12:30:00+02:00');
 
         $times = $time->getIntervals($start, $end);
 
@@ -45,12 +45,12 @@ final class TimeIntervalTest extends KernelTestCase
     /**
      * @throws \Exception
      */
-    public function testTimeIntervalTwoDays()
+    public function testTimeIntervalTwoDays(): void
     {
         $time = $this->getTimeService();
 
-        $start = new \DateTimeImmutable('2023-09-29T10:00:00+02:00');
-        $end = new \DateTimeImmutable('2023-09-30T12:30:00+02:00');
+        $start = \Carbon\CarbonImmutable::parse('2023-09-29T10:00:00+02:00');
+        $end = \Carbon\CarbonImmutable::parse('2023-09-30T12:30:00+02:00');
 
         $times = $time->getIntervals($start, $end);
 
@@ -59,21 +59,21 @@ final class TimeIntervalTest extends KernelTestCase
         $second = $times[1];
 
         $this->assertEquals($start, $first->start);
-        $this->assertEquals(new \DateTimeImmutable('2023-09-30T00:00:00+02:00'), $first->end);
+        $this->assertEquals(\Carbon\CarbonImmutable::parse('2023-09-30T00:00:00+02:00'), $first->end);
 
-        $this->assertEquals(new \DateTimeImmutable('2023-09-30T00:00:00+02:00'), $second->start);
+        $this->assertEquals(\Carbon\CarbonImmutable::parse('2023-09-30T00:00:00+02:00'), $second->start);
         $this->assertEquals($end, $second->end);
     }
 
     /**
      * @throws \Exception
      */
-    public function testTimeIntervalTwoDaysUTC()
+    public function testTimeIntervalTwoDaysUTC(): void
     {
         $time = $this->getTimeService();
 
-        $start = new \DateTimeImmutable('2023-09-29T10:00:00+00:00');
-        $end = new \DateTimeImmutable('2023-09-30T12:30:00+00:00');
+        $start = \Carbon\CarbonImmutable::parse('2023-09-29T10:00:00+00:00');
+        $end = \Carbon\CarbonImmutable::parse('2023-09-30T12:30:00+00:00');
 
         $times = $time->getIntervals($start, $end);
 
@@ -82,21 +82,21 @@ final class TimeIntervalTest extends KernelTestCase
         $second = $times[1];
 
         $this->assertEquals($start, $first->start);
-        $this->assertEquals(new \DateTimeImmutable('2023-09-30T00:00:00+02:00'), $first->end);
+        $this->assertEquals(\Carbon\CarbonImmutable::parse('2023-09-30T00:00:00+02:00'), $first->end);
 
-        $this->assertEquals(new \DateTimeImmutable('2023-09-30T00:00:00+02:00'), $second->start);
+        $this->assertEquals(\Carbon\CarbonImmutable::parse('2023-09-30T00:00:00+02:00'), $second->start);
         $this->assertEquals($end, $second->end);
     }
 
     /**
      * @throws \Exception
      */
-    public function testTimeIntervalMultiDays()
+    public function testTimeIntervalMultiDays(): void
     {
         $time = $this->getTimeService();
 
-        $start = new \DateTimeImmutable('2023-09-23T10:00:00+02:00');
-        $end = new \DateTimeImmutable('2023-09-30T12:30:00+02:00');
+        $start = \Carbon\CarbonImmutable::parse('2023-09-23T10:00:00+02:00');
+        $end = \Carbon\CarbonImmutable::parse('2023-09-30T12:30:00+02:00');
 
         $times = $time->getIntervals($start, $end);
 
@@ -105,8 +105,8 @@ final class TimeIntervalTest extends KernelTestCase
         $this->assertEquals($end, end($times)->end);
 
         // Test date in the middle of the range span the full day.
-        $this->assertEquals(new \DateTimeImmutable('2023-09-27T00:00:00+02:00'), $times[4]->start);
-        $this->assertEquals(new \DateTimeImmutable('2023-09-28T00:00:00+02:00'), $times[4]->end);
+        $this->assertEquals(\Carbon\CarbonImmutable::parse('2023-09-27T00:00:00+02:00'), $times[4]->start);
+        $this->assertEquals(\Carbon\CarbonImmutable::parse('2023-09-28T00:00:00+02:00'), $times[4]->end);
     }
 
     /**

--- a/tests/Utils/TestData.php
+++ b/tests/Utils/TestData.php
@@ -9,7 +9,7 @@ namespace App\Tests\Utils;
  */
 final class TestData
 {
-    public const FEED_ITEM_DATA = [
+    public const array FEED_ITEM_DATA = [
         'nid' => '30506',
         'url' => 'https://www.aakb.dk/arrangementer/teknologi/aabent-lab-60',
         'title' => 'Åbent Lab',
@@ -58,5 +58,5 @@ final class TestData
         ],
     ];
 
-    public const LONG_STRING = 'Lorem Ipsum is simply dummy teãxt of the printing and typesettiŝng industry. Lorem Ipsum has been the industry\'s staænard dummy text ever since the 15ø0s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.';
+    public const string LONG_STRING = 'Lorem Ipsum is simply dummy teãxt of the printing and typesettiŝng industry. Lorem Ipsum has been the industry\'s staænard dummy text ever since the 15ø0s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.';
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
 if (method_exists(Dotenv::class, 'bootEnv')) {
-    (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+    new Dotenv()->bootEnv(dirname(__DIR__).'/.env');
 }
 
 if ($_SERVER['APP_DEBUG']) {


### PR DESCRIPTION
Broaden the Rector configuration beyond the single Doctrine code-quality set, and apply it across the codebase.

## Changes

- **`rector.php`** — add `withPhpSets()`, version-based `withComposerBased(doctrine, symfony, phpunit)`, `withAttributesSets(...)`, and `withPreparedSets(deadCode, codeQuality, typeDeclarations, privatization, instanceOf, earlyReturn, carbon, doctrineCodeQuality, symfonyCodeQuality, phpunitCodeQuality)`. Process `tests/` in addition to `src/`.
- **Five documented skips** for rules that produced incorrect/unwanted output here: `IssetOnPropertyObjectToPropertyExistsRector` and `FlipTypeControlToUseExclusiveTypeRector` (unsafe isset/null-guard rewrites that broke `LocationFactory`/`OccurrencesFactory`), `ConstraintOptionsToNamedArgumentsRector` (passes a `TranslatableMessage` to a `string|null` param), `ParamTypeByMethodCallTypeRector` (widened an EasyAdmin filter's `false` label to `bool`), and `RemoveUnusedPrivateMethodRector` (the team suppresses `method.unused` rather than deleting).
- **Applied** across `src/` and `tests/` (coding style / imports left to php-cs-fixer, as before).
- **Baseline cleanup** — the type-aware `DisallowedEmptyRuleFixerRector` rewrote `empty()` to strict equivalents, clearing **6 of the 9** `empty.notAllowed` entries from `phpstan-baseline.neon`; the 3 remaining are `mixed`-typed and stay baselined. Baseline regenerated (net smaller).

## Why

The config only ran the Doctrine code-quality set; this brings the Symfony/PHPUnit/PHP/quality rules the project can benefit from. Rather than skip the strict-rules `empty()` fixer to avoid churn, this leans on the now-broader test suite to actually clear those level-8 baseline debts where Rector can do so safely.

The remaining ~71 baselined level-8 findings (`argument.type`, `method.nonObject`, `return.type`, `method.notFound`, boolean-condition strictness, etc.) are **not** mechanically fixable by Rector 2.5 and are left for a separate, manual pass.

## Verification

- `rector process --dry-run` — idempotent (no further changes)
- php-cs-fixer — clean
- PHPStan (level 8 + strict rules) — no errors
- Full PHPUnit suite — 194 tests, 454 assertions, green
