### PR TITLE
feat: guard in-use deletes and gracefully handle delete FK violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-106](https://github.com/itk-dev/event-database-imports/pull/106)
+  Guard Organization/Tag deletes against in-use records, and flash on a delete FK violation instead of a 409 page
 - [PR-105](https://github.com/itk-dev/event-database-imports/pull/105)
   Broaden the Rector config (PHP, Symfony, Doctrine, PHPUnit, code-quality sets) and apply it across src/ and tests/
 - [PR-104](https://github.com/itk-dev/event-database-imports/pull/104)

--- a/src/Controller/Admin/AbstractBaseCrudController.php
+++ b/src/Controller/Admin/AbstractBaseCrudController.php
@@ -8,7 +8,14 @@ use App\Entity\User;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Exception\EntityRemoveException;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Translation\TranslatableMessage;
 
 abstract class AbstractBaseCrudController extends AbstractCrudController
 {
@@ -22,6 +29,33 @@ abstract class AbstractBaseCrudController extends AbstractCrudController
     {
         return parent::configureActions($actions)
             ->add(Crud::PAGE_INDEX, Action::DETAIL);
+    }
+
+    /**
+     * Turn a foreign-key violation on delete into a friendly flash + redirect
+     * instead of EasyAdmin's raw 409 error page. Voters already hide/deny delete
+     * for the "in use" cases they know about (see the entity voters); this is the
+     * backstop for referential dependencies not mirrored in a voter.
+     */
+    #[\Override]
+    public function delete(AdminContext $context): KeyValueStore|Response
+    {
+        try {
+            return parent::delete($context);
+        } catch (EntityRemoveException) {
+            $this->addFlash('danger', new TranslatableMessage('admin.crud.delete.in_use'));
+
+            $urlGenerator = $this->container->get(AdminUrlGeneratorInterface::class);
+            assert($urlGenerator instanceof AdminUrlGeneratorInterface);
+
+            return $this->redirect(
+                $urlGenerator
+                    ->setController(static::class)
+                    ->setAction(Action::INDEX)
+                    ->unset(EA::ENTITY_ID)
+                    ->generateUrl()
+            );
+        }
     }
 
     #[\Override]

--- a/src/Security/Voter/OrganizationVoter.php
+++ b/src/Security/Voter/OrganizationVoter.php
@@ -52,9 +52,18 @@ final class OrganizationVoter extends Voter
         $organization = $subject['entity']->getInstance();
         assert($organization instanceof Organization);
 
-        // Delete is only allowed for editors
+        // Delete is only allowed for editors, and only when the organization is
+        // not referenced by any events, feeds or partner events — deleting a
+        // referenced organization would otherwise fail with a database
+        // foreign-key violation.
         if (Action::DELETE === $action) {
-            return $this->security->isGranted(UserRoles::ROLE_EDITOR->value);
+            if (!$this->security->isGranted(UserRoles::ROLE_EDITOR->value)) {
+                return false;
+            }
+
+            return $organization->getEvents()->isEmpty()
+                && $organization->getFeeds()->isEmpty()
+                && $organization->getPartnerEvents()->isEmpty();
         }
 
         // Global Admin/Editor users can edit all organizations

--- a/src/Security/Voter/TagVoter.php
+++ b/src/Security/Voter/TagVoter.php
@@ -33,9 +33,23 @@ final class TagVoter extends Voter
     {
         $action = is_string($subject['action']) ? $subject['action'] : $subject['action']->getName();
 
-        // Delete and edit are only allowed for admins.
-        if (Action::DELETE === $action || Action::EDIT === $action) {
+        // Edit is only allowed for admins.
+        if (Action::EDIT === $action) {
             return $this->security->isGranted(UserRoles::ROLE_ADMIN->value);
+        }
+
+        // Delete is only allowed for admins, and only when the tag is not
+        // attached to any events or vocabularies — a referenced tag would
+        // otherwise fail with a join-table foreign-key violation.
+        if (Action::DELETE === $action) {
+            if (!$this->security->isGranted(UserRoles::ROLE_ADMIN->value)) {
+                return false;
+            }
+
+            $tag = $subject['entity']->getInstance();
+            assert($tag instanceof Tag);
+
+            return $tag->getEvents()->isEmpty() && $tag->getVocabularies()->isEmpty();
         }
 
         // Index, detail, new and save are open to any authenticated user

--- a/tests/Functional/Admin/LocationDeleteActionVisibilityTest.php
+++ b/tests/Functional/Admin/LocationDeleteActionVisibilityTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Admin;
+
+use App\Controller\Admin\LocationCrudController;
+use App\DataFixtures\OrganizationFixtures;
+use App\Entity\Address;
+use App\Entity\Event;
+use App\Entity\Location;
+use App\Entity\Organization;
+use App\Tests\Fixtures\TestUserFixtures;
+use App\Tests\Functional\AbstractAdminTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * The Delete action must be hidden for a location that is still in use (has
+ * events): LocationVoter denies delete for used locations, and EasyAdmin
+ * consults the voter when building actions, so the button is not rendered.
+ * This pins the end-to-end behavior the voter guard exists to produce.
+ */
+final class LocationDeleteActionVisibilityTest extends AbstractAdminTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadFixtures([
+            OrganizationFixtures::class,
+            TestUserFixtures::class,
+        ]);
+    }
+
+    private function entityManager(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        $this->assertInstanceOf(EntityManagerInterface::class, $em);
+
+        return $em;
+    }
+
+    private function createLocation(string $name): Location
+    {
+        $address = new Address();
+        $address->setStreet($name.' Street 1')
+            ->setCity('Aarhus')
+            ->setCountry('DK')
+            ->setPostalCode('8000')
+            ->setRegion('Midtjylland')
+            ->setEditable(true);
+        $this->entityManager()->persist($address);
+
+        $location = new Location();
+        $location->setName($name)
+            ->setAddress($address);
+        $this->entityManager()->persist($location);
+
+        return $location;
+    }
+
+    /**
+     * A used location (attached to an event) offers no Delete action, while an
+     * otherwise-identical unused location does — proving the voter's "unused"
+     * guard reaches EasyAdmin's action rendering.
+     */
+    public function testDeleteHiddenForUsedLocationButShownForUnused(): void
+    {
+        $org = $this->entityManager()->getRepository(Organization::class)->findOneBy([]);
+        $this->assertInstanceOf(Organization::class, $org);
+
+        $unused = $this->createLocation('Unused location');
+        $used = $this->createLocation('Used location');
+
+        $event = new Event();
+        $event->setTitle('Event at used location')
+            ->setDescription('desc')
+            ->setUpdatedBy('test')
+            ->setEditable(true)
+            ->setOrganization($org)
+            ->setLocation($used);
+        $this->entityManager()->persist($event);
+        $this->entityManager()->flush();
+
+        $unusedId = $unused->getId();
+        $usedId = $used->getId();
+        $this->entityManager()->clear();
+
+        $this->loginAs(TestUserFixtures::EDITOR_EMAIL);
+
+        $unusedCrawler = $this->client->request(Request::METHOD_GET, $this->adminUrl(LocationCrudController::class, Action::DETAIL, ['entityId' => $unusedId]));
+        $this->assertResponseIsSuccessful();
+        $this->assertGreaterThan(0, $unusedCrawler->filter('.action-delete')->count(), 'Unused location should offer the Delete action.');
+
+        $usedCrawler = $this->client->request(Request::METHOD_GET, $this->adminUrl(LocationCrudController::class, Action::DETAIL, ['entityId' => $usedId]));
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(0, $usedCrawler->filter('.action-delete')->count(), 'Used location must not offer the Delete action.');
+    }
+}

--- a/tests/Functional/Admin/LocationDeleteActionVisibilityTest.php
+++ b/tests/Functional/Admin/LocationDeleteActionVisibilityTest.php
@@ -96,6 +96,6 @@ final class LocationDeleteActionVisibilityTest extends AbstractAdminTestCase
 
         $usedCrawler = $this->client->request(Request::METHOD_GET, $this->adminUrl(LocationCrudController::class, Action::DETAIL, ['entityId' => $usedId]));
         $this->assertResponseIsSuccessful();
-        $this->assertSame(0, $usedCrawler->filter('.action-delete')->count(), 'Used location must not offer the Delete action.');
+        $this->assertCount(0, $usedCrawler->filter('.action-delete'), 'Used location must not offer the Delete action.');
     }
 }

--- a/tests/Unit/Security/Voter/OrganizationVoterTest.php
+++ b/tests/Unit/Security/Voter/OrganizationVoterTest.php
@@ -90,6 +90,25 @@ final class OrganizationVoterTest extends TestCase
     }
 
     /**
+     * Denies delete for an editor when the organization still has events
+     * attached — a referenced organization cannot be deleted without a
+     * database foreign-key violation.
+     */
+    public function testDeleteDeniedWhenOrganizationInUse(): void
+    {
+        $voter = new OrganizationVoter($this->createSecurity([UserRoles::ROLE_EDITOR->value]));
+
+        $org = new Organization();
+        $org->addEvent(new Event());
+
+        $subject = ['entity' => $this->createEntityDto(Organization::class, $org), 'action' => Action::DELETE];
+        $this->assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->createToken(new User()), $subject, [Permission::EA_EXECUTE_ACTION]),
+        );
+    }
+
+    /**
      * Grants edit access to an editor for any organization.
      */
     public function testEditorCanEditAnyOrganization(): void

--- a/tests/Unit/Security/Voter/TagVoterTest.php
+++ b/tests/Unit/Security/Voter/TagVoterTest.php
@@ -70,6 +70,31 @@ final class TagVoterTest extends TestCase
     }
 
     /**
+     * Denies delete for an admin when the tag is still attached to an event —
+     * a referenced tag cannot be deleted without a join-table foreign-key
+     * violation. Edit remains granted.
+     */
+    public function testDeleteDeniedWhenTagInUse(): void
+    {
+        $voter = new TagVoter($this->createSecurity([UserRoles::ROLE_ADMIN->value]));
+
+        $tag = new Tag();
+        $tag->addEvent(new Event());
+
+        $deleteSubject = ['entity' => $this->createEntityDto(Tag::class, $tag), 'action' => Action::DELETE];
+        $this->assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->createToken(new User()), $deleteSubject, [Permission::EA_EXECUTE_ACTION]),
+        );
+
+        $editSubject = ['entity' => $this->createEntityDto(Tag::class, $tag), 'action' => Action::EDIT];
+        $this->assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->createToken(new User()), $editSubject, [Permission::EA_EXECUTE_ACTION]),
+        );
+    }
+
+    /**
      * Denies edit and delete actions to non-admin users.
      */
     public function testNonAdminCannotEditOrDeleteTag(): void

--- a/translations/messages+intl-icu.da.xlf
+++ b/translations/messages+intl-icu.da.xlf
@@ -677,6 +677,10 @@
         <source>admin.event.edited.created</source>
         <target state="needs-l10n">Oprettet</target>
       </trans-unit>
+      <trans-unit id="dLtcRm1" resname="admin.crud.delete.in_use">
+        <source>admin.crud.delete.in_use</source>
+        <target>Dette element kan ikke slettes, fordi det stadig er i brug af andre poster.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -677,6 +677,10 @@
         <source>admin.event.edited.created</source>
         <target>Created at</target>
       </trans-unit>
+      <trans-unit id="dLtcRm1" resname="admin.crud.delete.in_use">
+        <source>admin.crud.delete.in_use</source>
+        <target>This item cannot be deleted because it is still referenced by other records.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Follow-up to PR86: make delete actions behave correctly when a delete would be blocked, rather than showing a button that then errors.

## Background

EasyAdmin consults the entity voters when *building* row/detail actions (`ActionFactory::processEntityActions`), so a voter that denies DELETE already hides the button — this is why Location/Address (whose voters gate delete on "unused") already work. Two gaps remained:

- `OrganizationVoter` and `TagVoter` granted DELETE on role alone, so an in-use organization/tag still showed a Delete button that failed at the database with a foreign-key violation.
- EasyAdmin turns that FK violation into a 409 error *page*, not a friendly message.

## Changes

- **`OrganizationVoter`** — deny DELETE when the organization still has events, feeds or partner events (the relations that FK-block a delete).
- **`TagVoter`** — deny DELETE when the tag is still attached to events or vocabularies; edit remains admin-only. (Vocabulary *owns* its tag join table, so its delete does not FK-fail — no guard needed; audited.)
- **`AbstractBaseCrudController::delete()`** — catch `EntityRemoveException` (EA's wrapper around `ForeignKeyConstraintViolationException`) and show a flash + redirect to the index instead of the 409 page. Backstop for any referential dependency not mirrored in a voter.
- **Translations** — add `admin.crud.delete.in_use` (en/da).
- **Tests** — unit coverage for the used-org and used-tag delete denials; a functional test asserting the Delete action is hidden on a used location's detail page and shown for an unused one (proves the voter → EA action-rendering path end-to-end).

## Verification

- PHPStan (level 8 + strict) — no errors
- php-cs-fixer — clean
- Full PHPUnit suite — 197 tests, 470 assertions, green

## Note

The FK-catch itself isn't exercised by a functional test: the suite can't drive EasyAdmin's JS delete-confirmation modal headlessly (see the note in `CrudWriteRoundTripTest`), and with the voter guards in place an FK-violating delete is now hard to reach through the UI anyway. It remains as defense-in-depth.
