### PR TITLE
ci: add Rector gate, PostToolUse hook, and pr-readiness step

### DIFF
--- a/.claude/agents/pr-readiness.md
+++ b/.claude/agents/pr-readiness.md
@@ -14,9 +14,10 @@ Run these checks in order. Keep going after a failure (collect all results), but
 3. **Composer audit** — `docker compose exec -T phpfpm composer audit --locked --abandoned=report`
 4. **Coding standards** — `task coding-standards:check` (markdown + php-cs-fixer + twig + yaml)
 5. **PHPStan** — `task code-analysis:phpstan`
-6. **Test suite** — `task test` (provisions `db_test`, then PHPUnit). Report totals + any failures/errors; documented skips are fine.
-7. **Doctrine schema** — `docker compose exec -T phpfpm bin/console doctrine:schema:validate`
-8. **Index mappings in sync** — `task index:mappings:dump`, then `git diff --exit-code resources/mappings` must show no change (the `index-mappings` gate fails if a mapping class changed without the export being regenerated).
-9. **CHANGELOG updated** — `git diff --quiet origin/develop -- CHANGELOG.md` must show a change; the entry must be a wrapped `- [PR-N](url)\n  Description` line at the top of `[Unreleased]`, ordered by descending PR number.
+6. **Rector** — `docker compose exec -T phpfpm vendor/bin/rector process --dry-run` (the `rector` gate fails on any suggested change; run `task code-analysis:rector:apply` to fix).
+7. **Test suite** — `task test` (provisions `db_test`, then PHPUnit). Report totals + any failures/errors; documented skips are fine.
+8. **Doctrine schema** — `docker compose exec -T phpfpm bin/console doctrine:schema:validate`
+9. **Index mappings in sync** — `task index:mappings:dump`, then `git diff --exit-code resources/mappings` must show no change (the `index-mappings` gate fails if a mapping class changed without the export being regenerated).
+10. **CHANGELOG updated** — `git diff --quiet origin/develop -- CHANGELOG.md` must show a change; the entry must be a wrapped `- [PR-N](url)\n  Description` line at the top of `[Unreleased]`, ordered by descending PR number.
 
 Then report a pass/fail table (check · status · one-line detail) and a final verdict: READY or NOT READY, listing exactly what to fix. Do not modify any files — this is a read-only gate.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -114,6 +114,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); REL_PATH=\"${f#\"$CLAUDE_PROJECT_DIR\"/}\"; case \"$REL_PATH\" in src/*.php|tests/*.php) docker compose exec -T phpfpm vendor/bin/rector process --no-progress-bar \"$REL_PATH\" >/dev/null 2>&1 || true ;; esac",
+            "timeout": 60
+          },
+          {
+            "type": "command",
             "command": "f=$(jq -r '.tool_input.file_path // empty'); case \"$f\" in *.php) REL_PATH=\"${f#\"$CLAUDE_PROJECT_DIR\"/}\"; docker compose exec -T phpfpm vendor/bin/php-cs-fixer fix --quiet \"$REL_PATH\" 2>/dev/null || true ;; esac",
             "timeout": 30
           },

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -93,6 +93,31 @@ jobs:
       - name: Run PHPStan
         run: docker compose run --rm phpfpm vendor/bin/phpstan analyse
 
+  rector:
+    name: Rector
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Cache vendor
+        uses: actions/cache@v6
+        with:
+          path: vendor
+          key: vendor-php8.4-${{ hashFiles('composer.lock') }}
+          restore-keys: vendor-php8.4-
+
+      - name: Create docker network
+        run: docker network create frontend
+
+      - name: Pull container images
+        run: docker compose pull --quiet phpfpm
+
+      - name: Install Dependencies
+        run: docker compose run --rm phpfpm composer install
+
+      - name: Check for Rector suggestions
+        run: docker compose run --rm phpfpm vendor/bin/rector process --dry-run --no-progress-bar
+
   validate-doctrine-schema:
     runs-on: ubuntu-latest
     name: Validate Doctrine Schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-107](https://github.com/itk-dev/event-database-imports/pull/107)
+  Add a Rector CI gate (pr.yaml) and PostToolUse auto-fix hook, and list it in the pr-readiness checks
 - [PR-106](https://github.com/itk-dev/event-database-imports/pull/106)
   Guard Organization/Tag deletes against in-use records, and flash on a delete FK violation instead of a 409 page
 - [PR-105](https://github.com/itk-dev/event-database-imports/pull/105)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,9 +136,10 @@ cluster** — no shared database, no HTTP call between them.
 `.claude/settings.json`, `.claude/agents/`, `.claude/skills/`, and `.mcp.json` configure this repo's Claude Code
 setup. All hooks and MCP servers run tooling **inside the `phpfpm` container**.
 
-- **Hooks** — `SessionStart` boots the stack and checks host prerequisites; `PostToolUse` auto-runs php-cs-fixer,
-  phpstan, twig-cs-fixer, `composer normalize`, prettier, and markdownlint on the file you just edited (so
-  single-file changes don't need manual formatting); `PreToolUse` blocks edits to generated/locked/secret files
+- **Hooks** — `SessionStart` boots the stack and checks host prerequisites; `PostToolUse` auto-runs Rector (on
+  `src/` and `tests/` PHP), php-cs-fixer, phpstan, twig-cs-fixer, `composer normalize`, prettier, and markdownlint
+  on the file you just edited (so single-file changes don't need manual formatting); `PreToolUse` blocks edits to
+  generated/locked/secret files
   (`config/reference.php`, lock files, `.env.local`, `phpstan-baseline.neon`, …); `Stop` validates the DI container
   (`lint:container`) and warns on ES index-contract changes.
 - **Prerequisite:** `jq` must be installed on the **host** — the Edit/Write hooks read the edited file path from the

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Elasticsearch 8 and Valinor 2. `composer.json` holds the authoritative version c
 Every pull request must pass these GitHub Actions gates (`.github/workflows/`):
 
 - **`pr.yaml`** (Review) — composer validate + prod install, the full PHPUnit suite with coverage (→ Codecov),
-  PHPStan, and `doctrine:schema:validate`.
+  PHPStan, Rector (`--dry-run`), and `doctrine:schema:validate`.
 - **`composer.yaml`** — `composer validate --strict`, `composer normalize --dry-run`, and `composer audit`.
 - **`php.yaml`** — php-cs-fixer; **`twig.yaml`** — twig-cs-fixer; **`markdown.yaml`** — markdownlint;
   **`yaml.yaml`** — prettier `--check`.


### PR DESCRIPTION
Make Rector a first-class part of the workflow now that the broadened config (PR-105) is in place: enforce it in CI, run it in the pre-PR check, and auto-apply it while editing.

## Changes

- **CI gate** (`.github/workflows/pr.yaml`) — new `Rector` job running `rector process --dry-run --no-progress-bar`, mirroring the `code-analysis-rector` gate in the sibling `event-database-api` repo. Uses this repo's lighter `docker compose run --rm phpfpm` style (Rector needs no DB/ES), consistent with the existing PHPStan job.
- **PostToolUse hook** (`.claude/settings.json`) — auto-apply Rector to edited `src/`/`tests/` PHP files. Ordered **before** php-cs-fixer so php-cs-fixer cleans up Rector's output (e.g. shortens FQCNs), matching the existing auto-fixer chain. Scoped to `src/`/`tests/` because `rector process <path>` overrides the config paths and would otherwise rewrite `config/`, `migrations/`, `public/`.
- **pr-readiness agent** — add the Rector dry-run check to the CI-equivalent list.
- **Docs** — note the hook in CLAUDE.md and the gate in the README CI list.

## Why

Rector was advisory-only (`task code-analysis:rector`). With the config settled, gating it in CI keeps `develop` Rector-clean, and the auto-fix hook keeps edited files clean so PRs don't bounce on the new gate. Rector is an auto-fixer like php-cs-fixer/twig-cs-fixer/prettier, so it belongs in the same PostToolUse chain (PHPStan stays report-only because it can't auto-fix).

## Verification

- `rector process --dry-run` on the branch — clean (`Rector is done!`)
- `settings.json` valid JSON; `pr.yaml` passes Prettier; README/CLAUDE pass markdownlint
- Hook command verified: applies on a `src/` file, correctly skips non-`src`/`tests` paths

## Note

The hook auto-applies (silent, like the other fixers). Per-file Rector is ~1s with a warm cache. If auto-applying semantic refactors mid-edit feels too aggressive, it can be switched to `--dry-run` (report-only, like the PHPStan hook) — say the word.
