### PR TITLE
ci: scope image pulls to the services each job needs

### DIFF
--- a/.claude/agents/pr-readiness.md
+++ b/.claude/agents/pr-readiness.md
@@ -14,9 +14,10 @@ Run these checks in order. Keep going after a failure (collect all results), but
 3. **Composer audit** — `docker compose exec -T phpfpm composer audit --locked --abandoned=report`
 4. **Coding standards** — `task coding-standards:check` (markdown + php-cs-fixer + twig + yaml)
 5. **PHPStan** — `task code-analysis:phpstan`
-6. **Test suite** — `task test` (provisions `db_test`, then PHPUnit). Report totals + any failures/errors; documented skips are fine.
-7. **Doctrine schema** — `docker compose exec -T phpfpm bin/console doctrine:schema:validate`
-8. **Index mappings in sync** — `task index:mappings:dump`, then `git diff --exit-code resources/mappings` must show no change (the `index-mappings` gate fails if a mapping class changed without the export being regenerated).
-9. **CHANGELOG updated** — `git diff --quiet origin/develop -- CHANGELOG.md` must show a change; the entry must be a wrapped `- [PR-N](url)\n  Description` line at the top of `[Unreleased]`, ordered by descending PR number.
+6. **Rector** — `docker compose exec -T phpfpm vendor/bin/rector process --dry-run` (the `rector` gate fails on any suggested change; run `task code-analysis:rector:apply` to fix).
+7. **Test suite** — `task test` (provisions `db_test`, then PHPUnit). Report totals + any failures/errors; documented skips are fine.
+8. **Doctrine schema** — `docker compose exec -T phpfpm bin/console doctrine:schema:validate`
+9. **Index mappings in sync** — `task index:mappings:dump`, then `git diff --exit-code resources/mappings` must show no change (the `index-mappings` gate fails if a mapping class changed without the export being regenerated).
+10. **CHANGELOG updated** — `git diff --quiet origin/develop -- CHANGELOG.md` must show a change; the entry must be a wrapped `- [PR-N](url)\n  Description` line at the top of `[Unreleased]`, ordered by descending PR number.
 
 Then report a pass/fail table (check · status · one-line detail) and a final verdict: READY or NOT READY, listing exactly what to fix. Do not modify any files — this is a read-only gate.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -114,6 +114,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); REL_PATH=\"${f#\"$CLAUDE_PROJECT_DIR\"/}\"; case \"$REL_PATH\" in src/*.php|tests/*.php) docker compose exec -T phpfpm vendor/bin/rector process --no-progress-bar \"$REL_PATH\" >/dev/null 2>&1 || true ;; esac",
+            "timeout": 60
+          },
+          {
+            "type": "command",
             "command": "f=$(jq -r '.tool_input.file_path // empty'); case \"$f\" in *.php) REL_PATH=\"${f#\"$CLAUDE_PROJECT_DIR\"/}\"; docker compose exec -T phpfpm vendor/bin/php-cs-fixer fix --quiet \"$REL_PATH\" 2>/dev/null || true ;; esac",
             "timeout": 30
           },

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Composer install
         run: |
           docker network create frontend
-          docker compose run --rm --user=root -e APP_ENV=prod phpfpm composer install --no-dev --optimize-autoloader
-          docker compose run --rm --user=root -e APP_ENV=prod phpfpm composer clear-cache
+          docker compose run --rm --no-deps --user=root -e APP_ENV=prod phpfpm composer install --no-dev --optimize-autoloader
+          docker compose run --rm --no-deps --user=root -e APP_ENV=prod phpfpm composer clear-cache
 
       - name: Make assets dir
         run: |

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -14,9 +14,6 @@ env:
 jobs:
   create-release:
     runs-on: ubuntu-latest
-    env:
-      COMPOSER_ALLOW_SUPERUSER: 1
-      APP_ENV: prod
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -24,8 +21,8 @@ jobs:
       - name: Composer install
         run: |
           docker network create frontend
-          docker compose run --rm --no-deps --user=root -e APP_ENV=prod phpfpm composer install --no-dev --optimize-autoloader
-          docker compose run --rm --no-deps --user=root -e APP_ENV=prod phpfpm composer clear-cache
+          docker compose run --rm --no-deps -e APP_ENV=prod phpfpm composer install --no-dev --optimize-autoloader
+          docker compose run --rm --no-deps -e APP_ENV=prod phpfpm composer clear-cache
 
       - name: Make assets dir
         run: |

--- a/.github/workflows/index-mappings.yaml
+++ b/.github/workflows/index-mappings.yaml
@@ -37,10 +37,10 @@ jobs:
         run: docker compose pull --quiet phpfpm
 
       - name: Install dependencies
-        run: docker compose run --rm phpfpm composer install --no-interaction
+        run: docker compose run --rm --no-deps phpfpm composer install --no-interaction
 
       - name: Export index mappings
-        run: docker compose run --rm phpfpm bin/console app:index:mappings:dump --no-interaction
+        run: docker compose run --rm --no-deps phpfpm bin/console app:index:mappings:dump --no-interaction
 
       - name: Check for changes in committed mappings
         id: git-diff

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -93,6 +93,31 @@ jobs:
       - name: Run PHPStan
         run: docker compose run --rm phpfpm vendor/bin/phpstan analyse
 
+  rector:
+    name: Rector
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Cache vendor
+        uses: actions/cache@v6
+        with:
+          path: vendor
+          key: vendor-php8.4-${{ hashFiles('composer.lock') }}
+          restore-keys: vendor-php8.4-
+
+      - name: Create docker network
+        run: docker network create frontend
+
+      - name: Pull container images
+        run: docker compose pull --quiet phpfpm
+
+      - name: Install Dependencies
+        run: docker compose run --rm phpfpm composer install
+
+      - name: Check for Rector suggestions
+        run: docker compose run --rm phpfpm vendor/bin/rector process --dry-run --no-progress-bar
+
   validate-doctrine-schema:
     runs-on: ubuntu-latest
     name: Validate Doctrine Schema

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,10 +20,10 @@ jobs:
         run: docker compose pull --quiet phpfpm
 
       - name: Validate composer files
-        run: docker compose run --rm phpfpm composer validate composer.json --strict
+        run: docker compose run --rm --no-deps phpfpm composer validate composer.json --strict
 
       - name: Composer install with exported .env variables
-        run: docker compose run --rm --env APP_ENV=prod phpfpm composer install --no-dev --optimize-autoloader
+        run: docker compose run --rm --no-deps --env APP_ENV=prod phpfpm composer install --no-dev --optimize-autoloader
 
   test-suite:
     name: Test suite
@@ -88,10 +88,10 @@ jobs:
         run: docker compose pull --quiet phpfpm
 
       - name: Install Dependencies
-        run: docker compose run --rm phpfpm composer install
+        run: docker compose run --rm --no-deps phpfpm composer install
 
       - name: Run PHPStan
-        run: docker compose run --rm phpfpm vendor/bin/phpstan analyse
+        run: docker compose run --rm --no-deps phpfpm vendor/bin/phpstan analyse
 
   rector:
     name: Rector
@@ -113,10 +113,10 @@ jobs:
         run: docker compose pull --quiet phpfpm
 
       - name: Install Dependencies
-        run: docker compose run --rm phpfpm composer install
+        run: docker compose run --rm --no-deps phpfpm composer install
 
       - name: Check for Rector suggestions
-        run: docker compose run --rm phpfpm vendor/bin/rector process --dry-run --no-progress-bar
+        run: docker compose run --rm --no-deps phpfpm vendor/bin/rector process --dry-run --no-progress-bar
 
   validate-doctrine-schema:
     runs-on: ubuntu-latest
@@ -140,20 +140,20 @@ jobs:
           limit-access-to-actor: false
         if: 1 == runner.debug
 
-      # @TODO Fix this for real
-      - name: Allow Elastic search service to read and write in its data directory
-        run: |
-          mkdir -p .docker/data/elasticsearch/
-          chmod a+w .docker/data/elasticsearch/
-
-      - name: Install site
+      # Schema validation only needs the database; messenger:setup-transports
+      # needs the broker. Start just those (not the full stack: no Elasticsearch,
+      # nginx or mail) and run the console commands as one-off phpfpm containers.
+      - name: Start database and message broker
         run: |
           docker network create frontend
-          docker compose pull --quiet
-          docker compose up --detach
-          docker compose exec -T phpfpm composer install
-          docker compose exec -T phpfpm bin/console doctrine:migrations:migrate --no-interaction
-          docker compose exec -T phpfpm bin/console messenger:setup-transports
+          docker compose pull --quiet phpfpm mariadb rabbit
+          docker compose up --detach --wait mariadb rabbit
+
+      - name: Install dependencies and set up the schema
+        run: |
+          docker compose run --rm --no-deps phpfpm composer install
+          docker compose run --rm --no-deps phpfpm bin/console doctrine:migrations:migrate --no-interaction
+          docker compose run --rm --no-deps phpfpm bin/console messenger:setup-transports
 
       - name: Validate Doctrine schema
-        run: docker compose exec -T phpfpm bin/console doctrine:schema:validate
+        run: docker compose run --rm --no-deps phpfpm bin/console doctrine:schema:validate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ See [keep a changelog] for information about writing changes to this log.
 ## [Unreleased]
 
 - [PR-108](https://github.com/itk-dev/event-database-imports/pull/108)
-  Scope CI image pulls per job: `--no-deps` on the phpfpm-only jobs, and start DB/broker-only for schema validation
+  Scope CI image pulls per job (`--no-deps`), DB/broker-only schema validation, drop the release `--user=root`
 - [PR-107](https://github.com/itk-dev/event-database-imports/pull/107)
   Add a Rector CI gate (pr.yaml) and PostToolUse auto-fix hook, and list it in the pr-readiness checks
 - [PR-106](https://github.com/itk-dev/event-database-imports/pull/106)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-107](https://github.com/itk-dev/event-database-imports/pull/107)
+  Add a Rector CI gate (pr.yaml) and PostToolUse auto-fix hook, and list it in the pr-readiness checks
 - [PR-106](https://github.com/itk-dev/event-database-imports/pull/106)
   Guard Organization/Tag deletes against in-use records, and flash on a delete FK violation instead of a 409 page
 - [PR-105](https://github.com/itk-dev/event-database-imports/pull/105)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-108](https://github.com/itk-dev/event-database-imports/pull/108)
+  Scope CI image pulls per job: `--no-deps` on the phpfpm-only jobs, and start DB/broker-only for schema validation
 - [PR-107](https://github.com/itk-dev/event-database-imports/pull/107)
   Add a Rector CI gate (pr.yaml) and PostToolUse auto-fix hook, and list it in the pr-readiness checks
 - [PR-106](https://github.com/itk-dev/event-database-imports/pull/106)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,9 +136,10 @@ cluster** — no shared database, no HTTP call between them.
 `.claude/settings.json`, `.claude/agents/`, `.claude/skills/`, and `.mcp.json` configure this repo's Claude Code
 setup. All hooks and MCP servers run tooling **inside the `phpfpm` container**.
 
-- **Hooks** — `SessionStart` boots the stack and checks host prerequisites; `PostToolUse` auto-runs php-cs-fixer,
-  phpstan, twig-cs-fixer, `composer normalize`, prettier, and markdownlint on the file you just edited (so
-  single-file changes don't need manual formatting); `PreToolUse` blocks edits to generated/locked/secret files
+- **Hooks** — `SessionStart` boots the stack and checks host prerequisites; `PostToolUse` auto-runs Rector (on
+  `src/` and `tests/` PHP), php-cs-fixer, phpstan, twig-cs-fixer, `composer normalize`, prettier, and markdownlint
+  on the file you just edited (so single-file changes don't need manual formatting); `PreToolUse` blocks edits to
+  generated/locked/secret files
   (`config/reference.php`, lock files, `.env.local`, `phpstan-baseline.neon`, …); `Stop` validates the DI container
   (`lint:container`) and warns on ES index-contract changes.
 - **Prerequisite:** `jq` must be installed on the **host** — the Edit/Write hooks read the edited file path from the

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Elasticsearch 8 and Valinor 2. `composer.json` holds the authoritative version c
 Every pull request must pass these GitHub Actions gates (`.github/workflows/`):
 
 - **`pr.yaml`** (Review) — composer validate + prod install, the full PHPUnit suite with coverage (→ Codecov),
-  PHPStan, and `doctrine:schema:validate`.
+  PHPStan, Rector (`--dry-run`), and `doctrine:schema:validate`.
 - **`composer.yaml`** — `composer validate --strict`, `composer normalize --dry-run`, and `composer audit`.
 - **`php.yaml`** — php-cs-fixer; **`twig.yaml`** — twig-cs-fixer; **`markdown.yaml`** — markdownlint;
   **`yaml.yaml`** — prettier `--check`.


### PR DESCRIPTION
Audit and fix CI jobs that pull more container images than they use.

## Root cause

`phpfpm`'s `depends_on` merges across `docker-compose.yml` + `docker-compose.override.yml` to **mariadb + elasticsearch + rabbit**. So `docker compose run --rm phpfpm …` (no `--no-deps`) starts — and therefore pulls — all three, even for jobs that only run a static tool.

## Changes

**`--no-deps` on the phpfpm-only jobs** (they need no services, so they now pull only the `phpfpm` image):
- `pr.yaml`: Composer install, PHPStan, Rector
- `index-mappings.yaml`: composer install + `app:index:mappings:dump` (a schema-only export — verified it makes no Elasticsearch connection)
- `build_release.yml`: composer install + clear-cache

**`validate-doctrine-schema`: `run` over `up` + `exec`, scoped to what it needs.** The job does touch the database (`doctrine:schema:validate` compares the migrated DB schema against the mappings) and needs the broker (`messenger:setup-transports`), so it now starts **only mariadb + rabbit** (`up --detach --wait`) and runs the console commands as one-off `run --rm --no-deps phpfpm` containers. It no longer starts Elasticsearch, nginx or mail — which also let me delete the Elasticsearch data-dir `chmod` workaround.

**Left as-is:** `test-suite` legitimately needs the fuller stack — mariadb, phpfpm, and nginx (the `APP_PATH_PREFIX` asset smoke test makes a real HTTP request to nginx). The suite needs no rabbit (`when@test` → `in-memory://`) or live Elasticsearch, but those ride along as `phpfpm` deps; scoping them out would fight `depends_on` and isn't worth the fragility. Its only truly-unused image is `mail`.

## Verification

- Prettier passes on all changed workflows
- `--no-deps` confirmed working locally for PHPStan and `app:index:mappings:dump`
- Referenced services (`phpfpm`, `mariadb`, `rabbit`) exist in the resolved compose config

## Note

The synced, "do not edit" workflows (`composer.yaml`, `php.yaml`, `twig.yaml`) have the same `run --rm phpfpm` (no `--no-deps`) pattern and over-pull identically. They're generated from `itk-dev/devops_itkdev-docker`, so the fix belongs upstream there rather than in this repo (edits here would be overwritten by the next sync).

## Release workflow: drop redundant root user

Folded in: `build_release.yml` ran the composer steps with `--user=root` (plus `COMPOSER_ALLOW_SUPERUSER: 1`), but the job already runs as `runner` via the top-level `COMPOSE_USER: runner` — so both were redundant. Removed them and the now-unneeded job-level `env` block, aligning with the standard `build_release.yml` in `itk-dev/devops_itkdev-docker` (cf. their PR #116). `APP_ENV=prod` stays passed via `-e` on the run commands, and the `--no-deps` scoping from this PR is retained.
