### PR TITLE
chore: upgrade Elasticsearch to 8.19.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-110](https://github.com/itk-dev/event-database-imports/pull/110)
+  Upgrade Elasticsearch to 8.19.18 (dev image) and the `elasticsearch/elasticsearch` client constraint to `^8.19`
 - [PR-109](https://github.com/itk-dev/event-database-imports/pull/109)
   Update dev dependencies (minor/patch, in-constraint): php-cs-fixer, guzzle, phpdoc-parser, phpunit
 - [PR-108](https://github.com/itk-dev/event-database-imports/pull/108)

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "doctrine/orm": "^3.4",
         "dragonmantank/cron-expression": "^3.3",
         "easycorp/easyadmin-bundle": "^5.0",
-        "elasticsearch/elasticsearch": "^8.13",
+        "elasticsearch/elasticsearch": "^8.19",
         "guzzlehttp/guzzle": "^7.7",
         "league/uri": "^7.4",
         "liip/imagine-bundle": "^2.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "623a7eb1ce1913650ce74773694729e7",
+    "content-hash": "81f7362ed501e358c4e9875c500178b5",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -30,7 +30,7 @@ services:
       - RABBITMQ_ERLANG_COOKIE='d53f319cd7376f8f840aaf9889f315ab'
 
   elasticsearch:
-    image: elasticsearch:8.13.0
+    image: elasticsearch:8.19.18
     networks:
       - app
       - frontend


### PR DESCRIPTION
Bump Elasticsearch `8.13.0` → `8.19.18` (latest 8.x) and tighten the `elasticsearch/elasticsearch` client constraint `^8.13` → `^8.19`.

## Changes
- `docker-compose.override.yml`: dev ES image → `8.19.18`
- `composer.json`: client `^8.19` (lock already at 8.19.0; only the content-hash changes)

## Coordinated upgrade
Part of an Elasticsearch 8.19 bump across the three repos sharing the cluster:
- event-database-services — cluster image ([PR #2](https://github.com/itk-dev/event-database-services/pull/2))
- **event-database-imports — this PR**
- event-database-api — override image + client (PR to follow)

## Verification
Recreated ES locally as `8.19.18` and confirmed end-to-end:
- client connects; existing 8.13-created indices load (within-major data compatibility)
- `app:index:list` succeeds (all 7 indices/aliases resolve)
- PHPStan clean; full PHPUnit suite green (197 tests)

Within-major (8.13 → 8.19) is backward-compatible per Elastic's support policy. Deploy the shared cluster (services) first/with the clients.