### PR TITLE
Hotfix 1.2.6: fix re-import flash crash and deploy AMQP setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [1.2.6] - 2026-07-09
 
-- [PR-XX](https://github.com/itk-dev/event-database-imports/pull/XX)
+- [PR-112](https://github.com/itk-dev/event-database-imports/pull/112)
   - Fix the feed "Re-import" flash message crash by using a single, well-formed ICU plural (the `{count}`
     argument was declared with inconsistent types)
   - Add a RabbitMQ healthcheck and make the server `phpfpm`/`supervisor` services wait for it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+## [1.2.6] - 2026-07-09
+
+- [PR-XX](https://github.com/itk-dev/event-database-imports/pull/XX)
+  Fix the feed "Re-import" flash message crash by using a single, well-formed ICU plural (the `{count}`
+  argument was declared with inconsistent types)
+
 ## [1.2.5] - 2026-07-09
 
 - [PR-111](https://github.com/itk-dev/event-database-imports/pull/111)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ See [keep a changelog] for information about writing changes to this log.
 ## [1.2.6] - 2026-07-09
 
 - [PR-XX](https://github.com/itk-dev/event-database-imports/pull/XX)
-  Fix the feed "Re-import" flash message crash by using a single, well-formed ICU plural (the `{count}`
-  argument was declared with inconsistent types)
+  - Fix the feed "Re-import" flash message crash by using a single, well-formed ICU plural (the `{count}`
+    argument was declared with inconsistent types)
+  - Add a RabbitMQ healthcheck and make the server `phpfpm`/`supervisor` services wait for it
+    (`condition: service_healthy`), so `messenger:setup-transports` no longer fails on deploy before the
+    AMQP listener is ready
 
 ## [1.2.5] - 2026-07-09
 

--- a/docker-compose.server.override.yml
+++ b/docker-compose.server.override.yml
@@ -6,7 +6,8 @@ services:
       - PHP_UPLOAD_MAX_FILESIZE=40M
       - PHP_POST_MAX_SIZE=50M
     depends_on:
-      - rabbit
+      rabbit:
+        condition: service_healthy
 
   nginx:
     environment:
@@ -32,7 +33,8 @@ services:
     volumes:
       - .:/app
     depends_on:
-      - rabbit
+      rabbit:
+        condition: service_healthy
 
   rabbit:
     image: rabbitmq:4-management-alpine
@@ -43,5 +45,13 @@ services:
       - "RABBITMQ_DEFAULT_USER=${RABBITMQ_USER}"
       - "RABBITMQ_DEFAULT_PASS=${RABBITMQ_PASSWORD}"
       - "RABBITMQ_ERLANG_COOKIE=${RABBITMQ_ERLANG_COOKIE}"
+    healthcheck:
+      # Wait until the AMQP listener actually accepts connections; container
+      # "running" is not enough for messenger:setup-transports / consumers.
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "check_port_connectivity"]
+      start_period: 30s
+      interval: 10s
+      timeout: 10s
+      retries: 5
     volumes:
       - "./.docker/data/rabbit:/var/lib/rabbitmq/mnesia"

--- a/translations/messages+intl-icu.da.xlf
+++ b/translations/messages+intl-icu.da.xlf
@@ -423,7 +423,7 @@
       </trans-unit>
       <trans-unit id="reImpQu0" resname="admin.feed.reimport.queued">
         <source>admin.feed.reimport.queued</source>
-        <target state="translated">Sat {count} {count, plural, one {feed} other {feeds}} i kø til genimport.</target>
+        <target state="translated">{count, plural, one {Satte # feed i kø til genimport.} other {Satte # feeds i kø til genimport.}}</target>
       </trans-unit>
       <trans-unit id="DEmQ2O1" resname="admin.event.organizer.headline">
         <source>admin.event.organizer.headline</source>

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -423,7 +423,7 @@
       </trans-unit>
       <trans-unit id="reImpQu0" resname="admin.feed.reimport.queued">
         <source>admin.feed.reimport.queued</source>
-        <target>Queued {count} {count, plural, one {feed} other {feeds}} for re-import.</target>
+        <target>{count, plural, one {Queued # feed for re-import.} other {Queued # feeds for re-import.}}</target>
       </trans-unit>
       <trans-unit id="DEmQ2O1" resname="admin.event.organizer.headline">
         <source>admin.event.organizer.headline</source>


### PR DESCRIPTION
Hotfix for two issues surfaced by the 1.2.5 feed "Re-import" batch action in production.

## Changes

- **Flash message crash** — the `admin.feed.reimport.queued` translation declared `{count}` both as a bare placeholder and as a plural selector, which ICU rejects (`U_ARGUMENT_TYPE_MISMATCH`). Rendering the flash after a re-import 500'd the admin. Replaced with a single well-formed ICU plural (`da` + `en`).
- **Deploy failure** — `messenger:setup-transports` runs in a one-off `docker compose run --rm phpfpm` container that started before RabbitMQ was accepting AMQP connections (container "running" ≠ ready), failing with a socket error. Added a `rabbit` healthcheck and switched the server `phpfpm`/`supervisor` services to `depends_on: { rabbit: { condition: service_healthy } }` so the command waits for the AMQP listener.

## Why

Both bugs block using the re-import action / deploying: the flash crash makes the feed page unusable after a re-import, and the AMQP race fails the deploy playbook's `messenger:setup-transports` step. Changes are limited to two translation entries and the server docker-compose override; no application code changes.