### PR TITLE
Fix feed re-import batch action under EasyAdmin 5 (#[AdminRoute])

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-XX](https://github.com/itk-dev/event-database-imports/pull/XX)
+  Add the `#[AdminRoute]` attribute to the feed "Re-import" batch action so it works as a custom CRUD action
+  under EasyAdmin 5 (the action 500'd on `/admin/feed` without it)
 - [PR-110](https://github.com/itk-dev/event-database-imports/pull/110)
   Upgrade Elasticsearch to 8.19.18 (dev image) and the `elasticsearch/elasticsearch` client constraint to `^8.19`
 - [PR-109](https://github.com/itk-dev/event-database-imports/pull/109)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
-- [PR-XX](https://github.com/itk-dev/event-database-imports/pull/XX)
+- [PR-113](https://github.com/itk-dev/event-database-imports/pull/113)
   Add the `#[AdminRoute]` attribute to the feed "Re-import" batch action so it works as a custom CRUD action
   under EasyAdmin 5 (the action 500'd on `/admin/feed` without it)
 - [PR-110](https://github.com/itk-dev/event-database-imports/pull/110)

--- a/src/Controller/Admin/FeedCrudController.php
+++ b/src/Controller/Admin/FeedCrudController.php
@@ -6,6 +6,7 @@ use App\Entity\Feed;
 use App\Service\Feeds\Reader\FeedReader;
 use App\Service\Feeds\Reader\FeedReaderInterface;
 use App\Types\UserRoles;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
@@ -72,6 +73,7 @@ class FeedCrudController extends AbstractBaseCrudController
      * Dispatches an async ReadFeedMessage per (enabled) feed via the same path the
      * scheduler uses; disabled feeds are skipped.
      */
+    #[AdminRoute('/reimport', name: 'reimport')]
     public function reimportBatch(BatchActionDto $batchActionDto): Response
     {
         $feedIds = array_map(intval(...), $batchActionDto->getEntityIds());


### PR DESCRIPTION
Fix a develop-only regression: the feed "Re-import" batch action 500s on `/admin/feed` under EasyAdmin 5.

## Changes

- Add `#[AdminRoute('/reimport', name: 'reimport')]` to `FeedCrudController::reimportBatch()`.

## Why

EasyAdmin 5 requires custom CRUD actions wired via `linkToCrudAction()` to declare an `#[AdminRoute]` attribute; without it, `ActionFactory` throws a `RuntimeException` while building the action URL, 500ing the feed index. The batch action shipped in 1.2.5 on the EA4-based `main`/release line (which doesn't require the attribute), but `develop` runs EA5, so the gap only surfaces here. Verified the route registers (`admin_feed_reimport GET|POST /admin/feed/reimport`); PHPStan and cs clean.